### PR TITLE
fix: harden latest runtime hotfixes

### DIFF
--- a/scripts/patch_neoworker_auto_update.mjs
+++ b/scripts/patch_neoworker_auto_update.mjs
@@ -1,0 +1,298 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const asar = require('@electron/asar');
+const { Pickle } = require('@electron/asar/lib/pickle');
+
+const sourceArchive = path.resolve(
+  process.argv[2] ?? '/Applications/NeoWorker.app/Contents/Resources/app.asar',
+);
+const outputArchive = path.resolve(
+  process.argv[3] ?? '.novaready/package-output/app.auto-update.asar',
+);
+
+const mainBundlePath = 'dist/electron/electron/main.js';
+const updateManagerPath = 'dist/electron/electron/updater/update-manager.js';
+const rendererBundlePath = 'dist/renderer/assets/index-BTC5MTVk.js';
+const rendererCssPath = 'dist/renderer/assets/index-DuUtsx0I.css';
+
+let updateManagerSource = String.raw`"use strict";
+Object.defineProperty(exports,"__esModule",{value:true});
+exports.updateManager=exports.UpdateManager=void 0;
+const electron=require("electron");
+const fs=require("fs");
+const path=require("path");
+const crypto=require("crypto");
+const types=require("../../shared/types");
+class UpdateManager{
+mainWindow=null;
+repoOwner="Yuan-lab-LLM";
+repoName="NeoWorker";
+isUpdating=false;
+latestUpdate=null;
+manualDownloadPath=null;
+autoUpdater=null;
+setMainWindow(window){this.mainWindow=window}
+send(channel,payload){if(this.mainWindow&&!this.mainWindow.isDestroyed())this.mainWindow.webContents.send(channel,payload)}
+sendProgress(progress){this.send(types.IPC_CHANNELS.APP_UPDATE_PROGRESS,progress)}
+sendError(error){this.send(types.IPC_CHANNELS.APP_UPDATE_ERROR,{error:String(error||"更新失败")})}
+currentVersion(){return process.env.NEOWORKER_UPDATE_TEST_VERSION||electron.app.getVersion()}
+async getVersionInfo(){return{version:electron.app.getVersion(),isDev:!electron.app.isPackaged,isGitRepo:false,isNpmGlobal:false}}
+isNewerVersion(latest,current){const parse=value=>String(value||"").replace(/^v/,"").split(/[.+-]/).slice(0,3).map(part=>Number.parseInt(part,10)||0),a=parse(latest),b=parse(current);for(let i=0;i<3;i++){if(a[i]>b[i])return true;if(a[i]<b[i])return false}return false}
+releaseApiUrl(){return \`https://api.github.com/repos/\${this.repoOwner}/\${this.repoName}/releases/latest\`}
+assetUrlPrefix(){return \`https://github.com/\${this.repoOwner}/\${this.repoName}/releases/download/\`}
+normalizeRelease(release,currentVersion){if(!release||release.draft||release.prerelease)throw new Error("没有可用的正式版本");const latestVersion=String(release.tag_name||"").replace(/^v/,"");if(!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(latestVersion))throw new Error("GitHub Release 版本号格式无效");const prefix=this.assetUrlPrefix();const assets=Array.isArray(release.assets)?release.assets.filter(asset=>asset&&typeof asset.name==="string"&&typeof asset.browser_download_url==="string"&&asset.browser_download_url.startsWith(prefix)).map(asset=>({name:path.basename(asset.name),url:asset.browser_download_url,size:Number(asset.size)||0,digest:typeof asset.digest==="string"?asset.digest:null})):[];return{available:this.isNewerVersion(latestVersion,currentVersion),currentVersion,latestVersion,releaseNotes:typeof release.body==="string"?release.body:"",releaseUrl:typeof release.html_url==="string"?release.html_url:\`https://github.com/\${this.repoOwner}/\${this.repoName}/releases\`,publishedAt:release.published_at||null,updateMode:"electron-updater",assets}}
+async checkForUpdates(){const currentVersion=this.currentVersion();this.sendProgress({phase:"checking",message:"正在检查更新…"});try{const response=await electron.net.fetch(this.releaseApiUrl(),{headers:{Accept:"application/vnd.github+json","User-Agent":"NeoWorker-Updater"}});if(response.status===404){this.latestUpdate=null;return{available:false,currentVersion,latestVersion:currentVersion,updateMode:"electron-updater"}}if(!response.ok)throw new Error(\`GitHub 更新检查失败（\${response.status}）\`);const info=this.normalizeRelease(await response.json(),currentVersion);this.latestUpdate=info.available?info:null;return info}catch(error){this.sendError(error instanceof Error?error.message:String(error));throw error}}
+hasUpdaterMetadata(info){const pattern=process.platform==="darwin"?/^latest-mac\.yml$/i:process.platform==="win32"?/^latest\.yml$/i:/^latest-linux\.yml$/i;return info.assets.some(asset=>pattern.test(asset.name))}
+pickManualAsset(info){const arch=process.arch;const assets=info.assets;const patterns=process.platform==="darwin"?[arch==="arm64"?/arm64.*\.dmg$/i:/x64.*\.dmg$/i,/\.dmg$/i]:process.platform==="win32"?[arch==="arm64"?/arm64.*(?:setup)?\.exe$/i:/x64.*(?:setup)?\.exe$/i,/(?:setup|installer).*\.exe$/i,/\.exe$/i]:[/\.AppImage$/i,/\.deb$/i,/\.rpm$/i];for(const pattern of patterns){const asset=assets.find(candidate=>pattern.test(candidate.name));if(asset)return asset}return null}
+configureAutoUpdater(){if(this.autoUpdater)return this.autoUpdater;const updater=require("electron-updater").autoUpdater;updater.autoDownload=false;updater.autoInstallOnAppQuit=true;updater.allowPrerelease=false;updater.setFeedURL({provider:"github",owner:this.repoOwner,repo:this.repoName});updater.on("checking-for-update",()=>this.sendProgress({phase:"checking",message:"正在准备更新…"}));updater.on("download-progress",progress=>this.sendProgress({phase:"downloading",percent:Math.round(progress.percent),message:\`正在下载更新 \${Math.round(progress.percent)}%\`,bytesDownloaded:progress.transferred,bytesTotal:progress.total}));updater.on("update-downloaded",info=>{this.sendProgress({phase:"complete",percent:100,message:"更新已下载，可以重启安装"});this.send(types.IPC_CHANNELS.APP_UPDATE_DOWNLOADED,{requiresRestart:true,manual:false,version:info.version})});updater.on("error",error=>this.sendError(error.message));this.autoUpdater=updater;return updater}
+async downloadWithElectronUpdater(){const updater=this.configureAutoUpdater();const result=await updater.checkForUpdates();if(!result?.updateInfo||!this.isNewerVersion(result.updateInfo.version,electron.app.getVersion()))throw new Error("更新元数据与最新版本不匹配");await updater.downloadUpdate()}
+async downloadManualAsset(info){const asset=this.pickManualAsset(info);if(!asset)throw new Error("这个版本没有适用于当前系统的安装包");if(!asset.url.startsWith(this.assetUrlPrefix()))throw new Error("拒绝不受信任的更新地址");const downloads=electron.app.getPath("downloads");await fs.promises.mkdir(downloads,{recursive:true});const destination=path.join(downloads,asset.name);const temporary=\`\${destination}.download\`;await fs.promises.rm(temporary,{force:true});const response=await electron.net.fetch(asset.url,{headers:{"User-Agent":"NeoWorker-Updater"}});if(!response.ok||!response.body)throw new Error(\`更新下载失败（\${response.status}）\`);const total=Number(response.headers.get("content-length"))||asset.size||0;const handle=await fs.promises.open(temporary,"w");const hash=crypto.createHash("sha256");let transferred=0;try{const reader=response.body.getReader();for(;;){const {done,value}=await reader.read();if(done)break;const chunk=Buffer.from(value);await handle.write(chunk);hash.update(chunk);transferred+=chunk.length;const percent=total?Math.min(99,Math.round(transferred/total*100)):0;this.sendProgress({phase:"downloading",percent,message:percent?\`正在下载更新 \${percent}%\`:"正在下载更新…",bytesDownloaded:transferred,bytesTotal:total})}}finally{await handle.close()}const actual=hash.digest("hex");const expected=asset.digest?.match(/^sha256:([a-f0-9]{64})$/i)?.[1]?.toLowerCase();if(expected&&actual!==expected){await fs.promises.rm(temporary,{force:true});throw new Error("更新包校验失败，文件已删除")}await fs.promises.rm(destination,{force:true});await fs.promises.rename(temporary,destination);this.manualDownloadPath=destination;this.sendProgress({phase:"complete",percent:100,message:"安装包已下载"});this.send(types.IPC_CHANNELS.APP_UPDATE_DOWNLOADED,{requiresRestart:false,manual:true,path:destination,version:info.latestVersion})}
+async downloadAndInstallUpdate(){if(this.isUpdating)throw new Error("更新正在下载中");this.isUpdating=true;try{const info=this.latestUpdate||await this.checkForUpdates();if(!info?.available)throw new Error("当前已经是最新版本");if(this.hasUpdaterMetadata(info))await this.downloadWithElectronUpdater();else await this.downloadManualAsset(info)}catch(error){const message=error instanceof Error?error.message:String(error);this.sendProgress({phase:"error",message});this.sendError(message);throw error}finally{this.isUpdating=false}}
+async installUpdateAndRestart(){if(this.manualDownloadPath){const error=await electron.shell.openPath(this.manualDownloadPath);if(error)throw new Error(error);return{manual:true,path:this.manualDownloadPath}}if(this.autoUpdater){this.autoUpdater.quitAndInstall(false,true);return{manual:false}}throw new Error("还没有下载可安装的更新")}
+}
+exports.UpdateManager=UpdateManager;
+exports.updateManager=new UpdateManager();
+`.replaceAll('\\`', '`').replaceAll('\\${', '${');
+
+// GitHub's release metadata is available before the large CDN asset is ready.
+// Always use the streaming downloader here so the sidebar receives real byte
+// progress instead of electron-updater's initial 0% event hanging indefinitely.
+updateManagerSource = updateManagerSource
+  .replace(
+    'url:asset.browser_download_url,size:Number(asset.size)||0,digest:',
+    'url:asset.browser_download_url,apiUrl:typeof asset.url==="string"?asset.url:null,size:Number(asset.size)||0,digest:',
+  )
+  .replace(
+    'const response=await electron.net.fetch(asset.url,{headers:{"User-Agent":"NeoWorker-Updater"}});',
+    'const response=await electron.net.fetch(asset.apiUrl||asset.url,{headers:{"User-Agent":"NeoWorker-Updater",...(asset.apiUrl?{Accept:"application/octet-stream"}:{})}});',
+  )
+  .replace(
+    'const response=await electron.net.fetch(asset.apiUrl||asset.url,{headers:{"User-Agent":"NeoWorker-Updater",...(asset.apiUrl?{Accept:"application/octet-stream"}:{})}});',
+    'const controller=new AbortController(),timer=setTimeout(()=>controller.abort(),45000);let response;try{response=await electron.net.fetch(asset.apiUrl||asset.url,{headers:{"User-Agent":"NeoWorker-Updater",...(asset.apiUrl?{Accept:"application/octet-stream"}:{})},signal:controller.signal})}finally{clearTimeout(timer)}',
+  )
+  .replace(
+    'if(this.hasUpdaterMetadata(info))await this.downloadWithElectronUpdater();else await this.downloadManualAsset(info)',
+    'await this.downloadManualAsset(info)',
+  )
+  .replace(
+    'const reader=response.body.getReader();for(;;){const {done,value}=await reader.read();',
+    'const reader=response.body.getReader(),readChunk=()=>new Promise((resolve,reject)=>{const idleTimer=setTimeout(()=>reject(new Error("更新下载超时（45秒无数据）")),45000);reader.read().then(value=>{clearTimeout(idleTimer);resolve(value)},error=>{clearTimeout(idleTimer);reject(error)})});for(;;){const {done,value}=await readChunk();',
+  );
+
+const mainWindowAnchor = `            if (shouldStartMaximized) {`;
+const mainWindowWiring = `            require("./updater").updateManager.setMainWindow(mainWindow);\n            if (shouldStartMaximized) {`;
+const sidebarStateAnchor = `sn=Je.length>0;w.useEffect(()=>{window.electronAPI.getAgentRoles`;
+let sidebarState = `sn=Je.length>0;const[NWUpdate,NWSetUpdate]=w.useState(null),[NWProgressState,NWSetProgress]=w.useState(null),[NWReady,NWSetReady]=w.useState(null);w.useEffect(()=>{let F=!0,pe=()=>window.electronAPI?.checkForUpdates?.().then(xe=>{F&&(NWSetUpdate(xe?.available?xe:null),NWSetProgress(state=>state?.phase==="checking"?null:state))}).catch(()=>{F&&NWSetProgress(state=>state?.phase==="checking"?null:state)}),xe=setTimeout(pe,8e3),Ie=setInterval(pe,216e5),we=window.electronAPI?.onUpdateProgress?.(Qe=>{F&&NWSetProgress(Qe)}),Qe=window.electronAPI?.onUpdateDownloaded?.(qe=>{F&&(NWSetReady(qe),NWSetProgress({phase:"complete",percent:100}))}),et=window.electronAPI?.onUpdateError?.(()=>{F&&(NWSetProgress(null),NWSetReady(null))});return()=>{F=!1,clearTimeout(xe),clearInterval(Ie),we?.(),Qe?.(),et?.()}},[]);const NWBusy=NWProgressState?.phase==="downloading"||NWProgressState?.phase==="checking",NWPercent=Math.round(NWProgressState?.percent||0),NWLabel=NWReady?O(NWReady.manual?"sidebar.update.openInstaller":"sidebar.update.restart",NWReady.manual?"打开安装包":"重启更新"):NWProgressState?.phase==="checking"?O("sidebar.update.checking","正在检查更新…"):NWBusy?O("sidebar.update.downloading",\`正在下载 \${NWPercent}%\`,{percent:NWPercent}):O("sidebar.update.download",\`下载 v\${NWUpdate?.latestVersion||""}\`,{version:NWUpdate?.latestVersion||""}),NWTitle=NWReady?O("sidebar.update.readyTitle","更新已下载，点击安装"):NWProgressState?.phase==="checking"?O("sidebar.update.checking","正在检查更新…"):NWBusy?O("sidebar.update.progressTitle",\`正在下载 NeoWorker v\${NWUpdate?.latestVersion||""}：\${NWPercent}%\`,{version:NWUpdate?.latestVersion||"",percent:NWPercent}):O("sidebar.update.availableTitle",\`发现 NeoWorker v\${NWUpdate?.latestVersion||""}\`,{version:NWUpdate?.latestVersion||""}),NWClick=()=>{if(!NWUpdate){I?.();return}if(NWReady){window.electronAPI.installUpdate().catch(()=>{});return}NWSetProgress({phase:"downloading",percent:0}),window.electronAPI.downloadUpdate(NWUpdate).catch(()=>NWSetProgress(null))};w.useEffect(()=>{window.electronAPI.getAgentRoles`;
+
+// Do not call the checking phase "downloading 0%"; that misleading label was
+// the visible symptom reported by users while the release request was pending.
+sidebarState = sidebarState.replace(
+  'NWBusy?O("sidebar.update.downloading",`正在下载 ${NWPercent}%`,{percent:NWPercent})',
+  'NWProgressState?.phase==="checking"?O("sidebar.update.checking","正在检查更新…"):NWBusy?O("sidebar.update.downloading",`正在下载 ${NWPercent}%`,{percent:NWPercent})',
+);
+
+const oldGuideButton = `I&&h.jsxs("button",{className:"settings-btn cli-settings-btn cli-onboarding-btn",onClick:I,title:O("sidebar.setupWizard.title","Open setup guide"),"aria-label":O("sidebar.setupWizard.aria","Open setup guide"),children:[h.jsx("span",{className:"terminal-only",children:"[guide]"}),h.jsxs("span",{className:"modern-only",children:[h.jsx(Pc,{size:15,strokeWidth:2}),O("sidebar.setupWizard","Setup Guide")]})]})`;
+const newGuideButton = `(I||NWUpdate)&&h.jsxs("button",{className:\`settings-btn cli-settings-btn cli-onboarding-btn \${NWUpdate?"nw-update-btn":""}\`,onClick:NWClick,disabled:!!NWUpdate&&NWBusy,title:NWUpdate?NWTitle:O("sidebar.setupWizard.title","Open setup guide"),"aria-label":NWUpdate?NWTitle:O("sidebar.setupWizard.aria","Open setup guide"),children:[h.jsx("span",{className:"terminal-only",children:NWUpdate?"[update]":"[guide]"}),h.jsxs("span",{className:"modern-only",children:[NWUpdate?h.jsx("svg",{width:15,height:15,viewBox:"0 0 24 24",fill:"none",stroke:"currentColor",strokeWidth:2,strokeLinecap:"round",strokeLinejoin:"round","aria-hidden":"true",children:h.jsx("path",{d:"M12 3v12m-5-5 5 5 5-5M5 21h14"})}):h.jsx(Pc,{size:15,strokeWidth:2}),NWUpdate?NWLabel:O("sidebar.setupWizard","Setup Guide")]})]})`;
+
+const oldUpdateTranslations = `"updates.loading":"正在加载版本信息...","updates.currentVersion":"当前版本","updates.unknown":"未知","updates.developmentMode":"开发模式","updates.installedViaNpm":"通过 npm 安装","updates.check.title":"检查更新","updates.check.npm":"更新将通过 npm 安装。","updates.check.git":"更新将从 GitHub 拉取并自动重新构建。","updates.check.auto":"更新将自动下载并安装。","updates.checking":"正在检查...","updates.check.action":"检查更新","updates.available":"有可用更新！","updates.current":"当前","updates.latest":"最新","updates.released":"发布时间","updates.releaseNotes":"发行说明","updates.viewOnGithub":"在 GitHub 查看","updates.method":"更新方式","updates.upToDate":"已经是最新版本！","updates.updateNowNpm":"立即更新（npm install）","updates.updateNowGit":"立即更新（Git Pull + 重新构建）","updates.downloadInstall":"下载并安装更新","updates.restart":"重启以应用更新","updates.manual.title":"手动更新","updates.manual.description.command":"你也可以在终端运行这条命令手动更新：","updates.manual.description.commands":"你也可以在终端运行这些命令手动更新：","updates.manual.restartHint":"更新完成后，请重启应用以应用更改。",`;
+const newUpdateTranslations = ``;
+
+const updateCss = `.nw-update-btn{width:auto!important;max-width:170px!important;color:#fff!important;background:color-mix(in srgb,var(--color-brand-blue,#1e8df6) 78%,#000)!important;border-radius:999px!important;padding:0 11px!important;box-shadow:0 4px 12px color-mix(in srgb,var(--color-brand-blue,#1e8df6) 22%,transparent)!important}.nw-update-btn:hover{color:#fff!important;background:color-mix(in srgb,var(--color-brand-blue,#1e8df6) 70%,#000)!important}.nw-update-btn:disabled{cursor:progress!important;opacity:.82}.nw-update-btn .modern-only{gap:6px!important;white-space:nowrap;font-size:12px!important;line-height:1.2!important}.nw-update-btn .modern-only svg{width:15px;height:15px}`;
+
+function sha256(buffer) {
+  return crypto.createHash('sha256').update(buffer).digest('hex');
+}
+
+function archiveEntry(rawHeader, archivePath) {
+  let entry = rawHeader.header;
+  for (const segment of archivePath.split('/')) {
+    entry = entry?.files?.[segment];
+    if (!entry) throw new Error(`Missing ASAR entry: ${archivePath}`);
+  }
+  return entry;
+}
+
+function replaceExactlyOnce(source, from, to, label) {
+  const first = source.indexOf(from);
+  const last = source.lastIndexOf(from);
+  if (first < 0 || first !== last) {
+    throw new Error(`${label}: expected exactly one match, found ${first < 0 ? 0 : 'multiple'}`);
+  }
+  return source.slice(0, first) + to + source.slice(first + from.length);
+}
+
+function fitToOriginalSize(source, original, label) {
+  const patched = Buffer.from(source.trimEnd(), 'utf8');
+  if (patched.length > original.length) {
+    throw new Error(`${label}: patch grew by ${patched.length - original.length} bytes`);
+  }
+  return Buffer.concat([patched, Buffer.alloc(original.length - patched.length, 0x20)]);
+}
+
+function patchMainBundle(original) {
+  let source = original.toString('utf8').trimEnd();
+  if (!source.includes('updateManager.setMainWindow(mainWindow)')) {
+    source = replaceExactlyOnce(source, mainWindowAnchor, mainWindowWiring, 'updater window wiring');
+  }
+  return fitToOriginalSize(source, original, mainBundlePath);
+}
+
+function patchUpdateManager(original) {
+  if (Buffer.byteLength(updateManagerSource) > original.length) {
+    throw new Error(`${updateManagerPath}: replacement is too large`);
+  }
+  return fitToOriginalSize(updateManagerSource, original, updateManagerPath);
+}
+
+function removeLegacyUpdateBanner(source) {
+  const startNeedle = `q?.available&&!ie&&h.jsxs("div",{className:"sidebar-update-slot"`;
+  const endNeedle = `,h.jsxs("div",{className:"sidebar-brand-row"`;
+  const start = source.indexOf(startNeedle);
+  if (start < 0) return source;
+  const end = source.indexOf(endNeedle, start);
+  if (end < 0) throw new Error('legacy update banner end anchor was not found');
+  return source.slice(0, start) + `h.jsxs("div",{className:"sidebar-brand-row"` + source.slice(end + endNeedle.length);
+}
+
+function patchRendererBundle(original) {
+  let source = original.toString('utf8').trimEnd();
+  if (source.includes('const[NWUpdate,NWSetUpdate]')) {
+    let patched = source.replace(
+      'pe=()=>window.electronAPI?.checkForUpdates?.().then(xe=>{F&&NWSetUpdate(xe?.available?xe:null)}).catch(()=>{})',
+      'pe=()=>window.electronAPI?.checkForUpdates?.().then(xe=>{F&&(NWSetUpdate(xe?.available?xe:null),NWSetProgress(state=>state?.phase==="checking"?null:state))}).catch(()=>{F&&NWSetProgress(state=>state?.phase==="checking"?null:state)})',
+    );
+    patched = patched.replace(
+      'NWTitle=NWReady?O("sidebar.update.readyTitle","更新已下载，点击安装"):NWBusy?',
+      'NWTitle=NWReady?O("sidebar.update.readyTitle","更新已下载，点击安装"):NWProgressState?.phase==="checking"?O("sidebar.update.checking","正在检查更新…"):NWBusy?',
+    );
+    const checkingLabel = 'NWProgressState?.phase==="checking"?O("sidebar.update.checking","正在检查更新…"):';
+    while (patched.includes(`${checkingLabel}${checkingLabel}`)) {
+      patched = patched.replace(`${checkingLabel}${checkingLabel}`, checkingLabel);
+    }
+    return fitToOriginalSize(patched, original, rendererBundlePath);
+  }
+  source = removeLegacyUpdateBanner(source);
+  source = replaceExactlyOnce(
+    source,
+    `Bo();const[ie,Fe]=w.useState(!1),[ke`,
+    `Bo();const[ke`,
+    'remove dismissed legacy update state',
+  );
+  source = source.replace(
+    `&&(e.updateInfo?.latestVersion===n.updateInfo?.latestVersion)`,
+    '',
+  );
+  source = source.replace(
+    `,updateInfo:q,onViewUpdate:ge})`,
+    `})`,
+  );
+  source = source.replace(
+    `,updateInfo:null,onViewUpdate:()=>{qt("updates"),A("settings")}`,
+    ``,
+  );
+  source = replaceExactlyOnce(source, sidebarStateAnchor, sidebarState, 'sidebar updater state');
+  source = replaceExactlyOnce(source, oldGuideButton, newGuideButton, 'setup guide update button');
+  source = replaceExactlyOnce(
+    source,
+    oldUpdateTranslations,
+    newUpdateTranslations,
+    'update translations',
+  );
+  return fitToOriginalSize(source, original, rendererBundlePath);
+}
+
+function patchRendererCss(original) {
+  let source = original.toString('utf8').trimEnd();
+  if (source.includes('.nw-update-btn{')) return original;
+  const legacyStart = source.indexOf('.sidebar-update-actions{');
+  const legacyEnd = source.indexOf('button,input,select,textarea,a,', legacyStart);
+  if (legacyStart >= 0 && legacyEnd > legacyStart) {
+    source = source.slice(0, legacyStart) + source.slice(legacyEnd);
+  }
+  return fitToOriginalSize(source + updateCss, original, rendererCssPath);
+}
+
+if (!fs.existsSync(sourceArchive)) throw new Error(`Source ASAR not found: ${sourceArchive}`);
+if (sourceArchive === outputArchive) throw new Error('Refusing to patch the source archive in place');
+
+const rawHeader = asar.getRawHeader(sourceArchive);
+const patchSpecs = [
+  { archivePath: mainBundlePath, build: patchMainBundle },
+  { archivePath: updateManagerPath, build: patchUpdateManager },
+  { archivePath: rendererBundlePath, build: patchRendererBundle },
+  { archivePath: rendererCssPath, build: patchRendererCss },
+];
+const patches = patchSpecs.map(({ archivePath, build }) => {
+  const entry = archiveEntry(rawHeader, archivePath);
+  const original = asar.extractFile(sourceArchive, archivePath);
+  const patched = build(original);
+  if (Number(entry.size) !== original.length || patched.length !== original.length) {
+    throw new Error(`${archivePath}: ASAR entry size mismatch`);
+  }
+  const oldHash = entry.integrity?.hash;
+  if (!oldHash || entry.integrity?.algorithm !== 'SHA256') {
+    throw new Error(`${archivePath}: unsupported ASAR integrity metadata`);
+  }
+  if (!Array.isArray(entry.integrity.blocks) || entry.integrity.blocks.length !== 1) {
+    throw new Error(`${archivePath}: unsupported ASAR integrity block layout`);
+  }
+  return { archivePath, entry, original, patched, newHash: sha256(patched) };
+});
+
+fs.mkdirSync(path.dirname(outputArchive), { recursive: true });
+fs.copyFileSync(sourceArchive, outputArchive);
+const fd = fs.openSync(outputArchive, 'r+');
+try {
+  for (const patch of patches) {
+    const absoluteOffset = rawHeader.headerSize + 8 + Number(patch.entry.offset);
+    const current = Buffer.alloc(patch.original.length);
+    fs.readSync(fd, current, 0, current.length, absoluteOffset);
+    if (!current.equals(patch.original)) {
+      throw new Error(`${patch.archivePath}: source bytes do not match ASAR offset`);
+    }
+    fs.writeSync(fd, patch.patched, 0, patch.patched.length, absoluteOffset);
+    patch.entry.integrity.hash = patch.newHash;
+    patch.entry.integrity.blocks = [patch.newHash];
+  }
+  const headerPickle = Pickle.createEmpty();
+  headerPickle.writeString(JSON.stringify(rawHeader.header));
+  const headerBuffer = headerPickle.toBuffer();
+  if (headerBuffer.length !== rawHeader.headerSize) {
+    throw new Error(`ASAR header size changed from ${rawHeader.headerSize} to ${headerBuffer.length}`);
+  }
+  const sizePickle = Pickle.createEmpty();
+  sizePickle.writeUInt32(headerBuffer.length);
+  const sizeBuffer = sizePickle.toBuffer();
+  fs.writeSync(fd, sizeBuffer, 0, sizeBuffer.length, 0);
+  fs.writeSync(fd, headerBuffer, 0, headerBuffer.length, sizeBuffer.length);
+  fs.fsyncSync(fd);
+} finally {
+  fs.closeSync(fd);
+}
+
+asar.uncache(outputArchive);
+const verifiedHeader = asar.getRawHeader(outputArchive);
+for (const patch of patches) {
+  const verified = asar.extractFile(outputArchive, patch.archivePath);
+  const verifiedEntry = archiveEntry(verifiedHeader, patch.archivePath);
+  const digest = sha256(verified);
+  if (!verified.equals(patch.patched)) throw new Error(`${patch.archivePath}: verification failed`);
+  if (verifiedEntry.integrity?.hash !== digest || verifiedEntry.integrity?.blocks?.[0] !== digest) {
+    throw new Error(`${patch.archivePath}: integrity metadata mismatch`);
+  }
+}
+
+console.log(JSON.stringify({
+  sourceArchive,
+  outputArchive,
+  archiveBytes: fs.statSync(outputArchive).size,
+  patchedEntries: patches.map((patch) => ({
+    path: patch.archivePath,
+    bytes: patch.patched.length,
+    sha256: patch.newHash,
+  })),
+}, null, 2));

--- a/scripts/patch_neoworker_flight_route_general_v3.mjs
+++ b/scripts/patch_neoworker_flight_route_general_v3.mjs
@@ -1,0 +1,405 @@
+#!/usr/bin/env node
+
+/** Replace the fixed Beijing-Shanghai flight route with route-agnostic city/IATA routing and reliable-source fallback. */
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const asar = require("@electron/asar");
+const { Pickle } = require("@electron/asar/lib/pickle");
+
+const sourceArchive = path.resolve(process.argv[2] || "/Applications/NeoWorker.app/Contents/Resources/app.asar");
+const outputArchive = path.resolve(process.argv[3] || ".novaready/package-output/app.asar.flight-route-general-v14");
+const runtimes = ["electron", "daemon", "cli"];
+const marker = "NW_FLIGHT_ROUTE_GENERAL_V13";
+const providerMarker = "NW_FLIGHT_SEARCH_PROVIDER_V1";
+const sha256 = (value) => crypto.createHash("sha256").update(value).digest("hex");
+
+function packedEntries(node, prefix = "", out = []) {
+  for (const [name, entry] of Object.entries(node.files || {})) {
+    const archivePath = prefix ? `${prefix}/${name}` : name;
+    if (entry.files) packedEntries(entry, archivePath, out);
+    else if (!entry.unpacked && entry.offset !== undefined) out.push({ archivePath, entry, oldOffset: Number(entry.offset), oldSize: Number(entry.size) });
+  }
+  return out;
+}
+
+function updateIntegrity(entry, content) {
+  if (!entry.integrity) return;
+  entry.integrity.hash = sha256(content);
+  if (!Array.isArray(entry.integrity.blocks)) return;
+  const blockSize = Number(entry.integrity.blockSize || content.length || 1);
+  entry.integrity.blocks = [];
+  for (let offset = 0; offset < content.length; offset += blockSize) entry.integrity.blocks.push(sha256(content.subarray(offset, Math.min(content.length, offset + blockSize))));
+  if (!entry.integrity.blocks.length) entry.integrity.blocks.push(sha256(content));
+}
+
+function writeArchive(patches) {
+  const raw = asar.getRawHeader(sourceArchive);
+  const entries = packedEntries(raw.header).sort((a, b) => a.oldOffset - b.oldOffset);
+  const map = new Map(patches.map((item) => [item.archivePath, item.patched]));
+  const found = new Set();
+  let nextOffset = 0;
+  for (const item of entries) {
+    item.entry.offset = String(nextOffset);
+    const patched = map.get(item.archivePath);
+    if (patched) {
+      found.add(item.archivePath);
+      item.entry.size = patched.length;
+      updateIntegrity(item.entry, patched);
+    }
+    nextOffset += Number(item.entry.size);
+  }
+  for (const archivePath of map.keys()) if (!found.has(archivePath)) throw new Error(`Missing packed entry: ${archivePath}`);
+  const headerPickle = Pickle.createEmpty();
+  headerPickle.writeString(JSON.stringify(raw.header));
+  const header = headerPickle.toBuffer();
+  const sizePickle = Pickle.createEmpty();
+  sizePickle.writeUInt32(header.length);
+  fs.mkdirSync(path.dirname(outputArchive), { recursive: true });
+  const sourceFd = fs.openSync(sourceArchive, "r");
+  const outputFd = fs.openSync(outputArchive, "w");
+  const dataStart = raw.headerSize + 8;
+  const buffer = Buffer.allocUnsafe(4 * 1024 * 1024);
+  try {
+    fs.writeSync(outputFd, sizePickle.toBuffer());
+    fs.writeSync(outputFd, header);
+    for (const item of entries) {
+      const patched = map.get(item.archivePath);
+      if (patched) {
+        fs.writeSync(outputFd, patched);
+        continue;
+      }
+      let remaining = item.oldSize;
+      let offset = dataStart + item.oldOffset;
+      while (remaining > 0) {
+        const count = Math.min(remaining, buffer.length);
+        fs.readSync(sourceFd, buffer, 0, count, offset);
+        fs.writeSync(outputFd, buffer, 0, count);
+        remaining -= count;
+        offset += count;
+      }
+    }
+    fs.fsyncSync(outputFd);
+  } finally {
+    fs.closeSync(sourceFd);
+    fs.closeSync(outputFd);
+  }
+}
+
+function patchExecutorHelpers(original, archivePath) {
+  let source = original.toString("utf8");
+  if (source.includes(marker)) return Buffer.from(source);
+  const start = source.indexOf("    const buildVariants = (rawQuery) => {");
+  const end = source.indexOf("    const familyForHost", start);
+  if (start < 0 || end < 0) throw new Error(`${archivePath}: buildVariants block not found`);
+  const replacement = String.raw`    const buildVariants = (rawQuery) => {
+        const base = normalizeSpace(rawQuery);
+        if (!base || /\bsite:/i.test(base))
+            return [base];
+        const variants = [];
+        const add = (value) => {
+            const normalized = normalizeSpace(value);
+            if (normalized && !variants.some((item) => item.toLowerCase() === normalized.toLowerCase()))
+                variants.push(normalized);
+        };
+        add(base);
+        const chinese = /[\u3400-\u9fff]/u.test(base);
+        const flight = /(?:航班|机票|航线|起飞|到达|票价|飞行时间|机场|航空|flight|airfare|airline|airport|departure|arrival)/i.test(base);
+        const cityCodes = { 北京: "PEK", 上海: "SHA", 广州: "CAN", 深圳: "SZX", 沈阳: "SHE", 成都: "CTU", 重庆: "CKG", 西安: "XIY", 杭州: "HGH", 南京: "NKG", 武汉: "WUH", 厦门: "XMN", 昆明: "KMG", 长沙: "CSX", 青岛: "TAO", 大连: "DLC", 哈尔滨: "HRB", 郑州: "CGO", 海口: "HAK", 三亚: "SYX", 天津: "TSN", 济南: "TNA", 福州: "FOC", 宁波: "NGB", 乌鲁木齐: "URC", 贵阳: "KWE", 南昌: "KHN", 合肥: "HFE", 温州: "WNZ", 兰州: "LHW", 石家庄: "SJW", 太原: "TYN", 呼和浩特: "HET", 长春: "CGQ", 桂林: "KWL", 珠海: "ZUH", 汕头: "SWA", 惠州: "HUZ", 洛阳: "LYA", 烟台: "YNT", 威海: "WEH", 徐州: "XUZ", 常州: "CZX", 南宁: "NNG", 银川: "INC", 西宁: "XNN", 拉萨: "LXA", 鄂尔多斯: "DSN", 海拉尔: "HLD", 牡丹江: "MDG", 张家界: "DYG", 宜昌: "YIH", 绵阳: "MIG", 泉州: "JJN", 黄山: "TXN", 赣州: "KOW", 香港: "HKG", 澳门: "MFM", 台北: "TPE" };
+        if (!chinese) {
+            const airportCodes = (base.match(/\b[A-Z]{3}\b/g) || []).slice(0, 2);
+            const englishCodes = { beijing: "PEK", shanghai: "SHA", guangzhou: "CAN", shenzhen: "SZX", shenyang: "SHE", chengdu: "CTU", chongqing: "CKG", xian: "XIY", hangzhou: "HGH", nanjing: "NKG", wuhan: "WUH", xiamen: "XMN", kunming: "KMG", changsha: "CSX", qingdao: "TAO", dalian: "DLC", harbin: "HRB", zhengzhou: "CGO", haikou: "HAK", sanya: "SYX", tianjin: "TSN", jinan: "TNA", fuzhou: "FOC", ningbo: "NGB", urumqi: "URC", guiyang: "KWE", nanchang: "KHN", hefei: "HFE", wenzhou: "WNZ", lanzhou: "LHW", shijiazhuang: "SJW", taiyuan: "TYN", hohhot: "HET", changchun: "CGQ", guilin: "KWL", zhuhai: "ZUH", shantou: "SWA", huizhou: "HUZ", luoyang: "LYA", yantai: "YNT", weihai: "WEH", xuzhou: "XUZ", changzhou: "CZX", nanning: "NNG", yinchuan: "INC", xining: "XNN", lhasa: "LXA", hongkong: "HKG", macau: "MFM", taipei: "TPE" };
+            const englishRouteCodes = Object.entries(englishCodes).filter(([name]) => new RegExp("\\b" + name + "\\b", "i").test(base)).map(([, code]) => code).slice(0, 2);
+            const routeCodes = airportCodes.length >= 2 ? airportCodes : englishRouteCodes;
+            const routeLabel = routeCodes.length >= 2 ? routeCodes.join(" ") : "";
+            add(base + (flight ? " " + routeLabel + " flight schedule" : " official source"));
+            if (flight) {
+                add(base + " site:trip.com");
+                add(base + " site:zbordirect.com");
+                add(base + " airline official schedule");
+            }
+            else if (/\b(code|software|library|framework|mcp|github|repository|api|model)\b/i.test(base)) add(base + " GitHub documentation");
+            else if (/\b(latest|current|today|news|recent|update|release)\b/i.test(base)) add(base + " latest announcement");
+            else add(base + " independent analysis");
+            return variants.slice(0, 4);
+        }
+        const core = base
+            .replace(/^(?:请|麻烦|劳驾)?(?:帮我|帮忙)?(?:查一下|查询一下|搜索一下|搜一下|看看|了解一下|分析一下|研究一下)/u, "")
+            .replace(/[？?。！!]+$/u, "").trim() || base;
+        if (flight) {
+            const foundCities = Object.entries(cityCodes).filter(([city]) => core.includes(city)).sort((a, b) => core.indexOf(a[0]) - core.indexOf(b[0]));
+            const foundCodes = (core.match(/\b[A-Z]{3}\b/g) || []).map((code) => [code, code]);
+            const route = foundCities.length >= 2 ? foundCities.slice(0, 2) : foundCodes.slice(0, 2);
+            const routeLabel = route.length >= 2 ? route.map((item) => item[0] + " " + item[1]).join(" ") : "";
+            const iso = base.match(/\b(20\d{2})[-年](\d{1,2})[-月](\d{1,2})日?\b/);
+            const monthDay = base.match(/(\d{1,2})\s*月\s*(\d{1,2})\s*[日号]?/);
+            const relative = /后天|day after tomorrow/i.test(base) ? 2 : /明天|tomorrow/i.test(base) ? 1 : /今天|today/i.test(base) ? 0 : null;
+            const now = new Date();
+            const date = iso ? iso[1] + "-" + String(iso[2]).padStart(2, "0") + "-" + String(iso[3]).padStart(2, "0") : monthDay ? now.getFullYear() + "-" + String(monthDay[1]).padStart(2, "0") + "-" + String(monthDay[2]).padStart(2, "0") : relative === null ? "" : new Date(now.getTime() + relative * 86400000).toISOString().slice(0, 10);
+            add(core + " " + routeLabel + " " + date + " site:trip.com");
+            add(core + " " + routeLabel + " " + date + " site:zbordirect.com");
+            add(core + " " + routeLabel + " " + date + " 航班时刻表");
+            add(core + " " + routeLabel + " " + date + " airline official schedule");
+            return variants.slice(0, 4);
+        }
+        const current = /最新|近期|最近|现在|目前|今天|今日|新闻|动态|进展|发布|更新/u.test(base);
+        const finance = /股票|股价|上市公司|财报|业绩|融资|估值|营收|利润|证券|基金/u.test(base);
+        const technical = /代码|软件|开源|项目|仓库|GitHub|API|MCP|框架|模型|技术/u.test(base);
+        const policy = /政策|法规|条例|办法|通知|政府|标准/u.test(base);
+        add(core + " 官方原文");
+        if (finance) { add(core + " 公告 财报"); add(core + " site:cninfo.com.cn"); }
+        else if (technical) { add(core + " GitHub 官方文档"); add(core + (current ? " release changelog" : " 技术文档")); }
+        else if (policy) { add(core + " site:gov.cn"); add(core + " 权威解读"); }
+        else { add(core + (current ? " 最新进展" : " 权威资料")); add(core + (/对比|比较|竞品|区别|优缺点/u.test(base) ? " 独立对比 评测" : " 独立分析")); }
+        return variants.slice(0, 4);
+    };
+`;
+  source = source.slice(0, start) + replacement + source.slice(end);
+  return Buffer.from(source + `\n/* ${marker}: generic city-pair and IATA-aware flight query expansion. */\n`, "utf8");
+}
+
+function patchSearchTools(original, archivePath) {
+  let source = original.toString("utf8");
+  // Re-enter the replacement when an older route patch is present but lacks
+  // the direction/OTA-alias safeguards added below.  This keeps regeneration
+  // idempotent while allowing V13/V14 artifacts to receive the follow-up fix.
+  if (source.includes(marker) && source.includes("const ordered") && source.includes("tripCityCodes")) return Buffer.from(source);
+  const start = source.indexOf("buildFlightEvidencePolicy(input) {");
+  const end = source.indexOf("\n\n    async webSearch(input) {", start);
+  if (start < 0 || end < 0) throw new Error(`${archivePath}: flight policy block not found`);
+  const replacement = String.raw`buildFlightEvidencePolicy(input) {
+        const query = String(input?.query || "").trim();
+        if (!this.isFlightQueryText(query)) return null;
+        const dateAnchor = this.extractFlightDateAnchor(query);
+        const route = this.extractFlightRouteCodes(query);
+        return { category: "flight_search", dateAnchor, dateAnchorRequired: true, airportScope: route?.routeLabel || "按查询原文锁定出发与到达机场", searchSnippetsAreLeads: true, indexedDateEvidenceAllowed: true, exactFlightDetailsVerified: false, livePricesVerified: false, warning: "搜索摘要默认只能发现来源；但当索引摘要同时明确包含目标日期、出发/到达航点、航班号和起降时间时，可以标为索引班期参考（不可视为实时余票或价格）。" };
+    }
+    extractFlightRouteCodes(value) {
+        const text = String(value || "");
+        const cityCodes = { 北京: ["PEK", "beijing"], 上海: ["SHA", "shanghai"], 广州: ["CAN", "guangzhou"], 深圳: ["SZX", "shenzhen"], 沈阳: ["SHE", "shenyang"], 成都: ["CTU", "chengdu"], 重庆: ["CKG", "chongqing"], 西安: ["XIY", "xian"], 杭州: ["HGH", "hangzhou"], 南京: ["NKG", "nanjing"], 武汉: ["WUH", "wuhan"], 厦门: ["XMN", "xiamen"], 昆明: ["KMG", "kunming"], 长沙: ["CSX", "changsha"], 青岛: ["TAO", "qingdao"], 大连: ["DLC", "dalian"], 哈尔滨: ["HRB", "harbin"], 郑州: ["CGO", "zhengzhou"], 海口: ["HAK", "haikou"], 三亚: ["SYX", "sanya"], 天津: ["TSN", "tianjin"], 济南: ["TNA", "jinan"], 福州: ["FOC", "fuzhou"], 宁波: ["NGB", "ningbo"], 乌鲁木齐: ["URC", "urumqi"], 贵阳: ["KWE", "guiyang"], 南昌: ["KHN", "nanchang"], 合肥: ["HFE", "hefei"], 温州: ["WNZ", "wenzhou"], 兰州: ["LHW", "lanzhou"], 石家庄: ["SJW", "shijiazhuang"], 太原: ["TYN", "taiyuan"], 呼和浩特: ["HET", "hohhot"], 长春: ["CGQ", "changchun"], 桂林: ["KWL", "guilin"], 珠海: ["ZUH", "zhuhai"], 汕头: ["SWA", "shantou"], 惠州: ["HUZ", "huizhou"], 洛阳: ["LYA", "luoyang"], 烟台: ["YNT", "yantai"], 威海: ["WEH", "weihai"], 徐州: ["XUZ", "xuzhou"], 常州: ["CZX", "changzhou"], 南宁: ["NNG", "nanning"], 银川: ["INC", "yinchuan"], 西宁: ["XNN", "xining"], 拉萨: ["LXA", "lhasa"], 鄂尔多斯: ["DSN", "ordos"], 海拉尔: ["HLD", "hailaer"], 牡丹江: ["MDG", "mudanjiang"], 张家界: ["DYG", "zhangjiajie"], 宜昌: ["YIH", "yichang"], 绵阳: ["MIG", "mianyang"], 泉州: ["JJN", "quanzhou"], 黄山: ["TXN", "huangshan"], 赣州: ["KOW", "ganzhou"], 香港: ["HKG", "hongkong"], 澳门: ["MFM", "macau"], 台北: ["TPE", "taipei"] };
+        const found = Object.entries(cityCodes).filter(([city, meta]) => text.includes(city) || new RegExp("\\b" + meta[1] + "\\b", "i").test(text)).sort((a, b) => text.indexOf(a[0]) - text.indexOf(b[0]));
+        const matched = found.length >= 2 ? found.slice(0, 2) : null;
+        const codes = matched ? matched.map((entry) => entry[1][0]) : (text.match(/\b[A-Z]{3}\b/g) || []).slice(0, 2);
+        if (codes.length < 2) return null;
+        const names = matched ? matched.map((entry) => entry[0]) : codes;
+        const slugs = matched ? matched.map((entry) => entry[1][1]) : codes.map((code) => code.toLowerCase());
+        // OTA city pages sometimes use a city code that differs from the airport
+        // IATA code (Xi'an is SIA on Trip.com/Ctrip but XIY at the airport).
+        const tripCityCodes = { 西安: "SIA", xian: "SIA" };
+        const tripCodes = names.map((name, index) => tripCityCodes[name] || codes[index]);
+        return { fromCity: names[0], fromCode: codes[0], fromTripCode: tripCodes[0], fromSlug: slugs[0], toCity: names[1], toCode: codes[1], toTripCode: tripCodes[1], toSlug: slugs[1], routeLabel: names[0] + " (" + codes[0] + ") → " + names[1] + " (" + codes[1] + ")" };
+    }
+    annotateFlightSearchResponse(response, input) {
+        const policy = this.buildFlightEvidencePolicy(input);
+        if (!policy) return response;
+        const rows = Array.isArray(response?.results) ? response.results : [];
+        const route = this.extractFlightRouteCodes(String(input?.query || ""));
+        const routePattern = route ? null : /(?:flightconnections|airpaz|traveloka|flightsfrom|zbordirect|ctrip|trip\\.com|qunar|airchina|hnair|ceair|航班|机票|航线|航空|机场)/i;
+        const relevant = rows.filter((row) => {
+            const rowText = String((row?.title || "") + " " + (row?.snippet || "") + " " + (row?.url || ""));
+            if (!route) return routePattern.test(rowText);
+            // Match the requested direction, not merely the unordered airport pair.
+            // Reverse-direction pages are common in search results (for example
+            // XIY→HGH when the user asked for HGH→XIY) and must not be presented
+            // as evidence for the requested route.
+            const ordered = (from, to) => {
+                const forward = new RegExp("\\b" + from + "\\b[\\s\\S]{0,140}\\b" + to + "\\b", "i");
+                const fromIndex = rowText.search(new RegExp("\\b" + from + "\\b", "i"));
+                const toIndex = rowText.search(new RegExp("\\b" + to + "\\b", "i"));
+                return forward.test(rowText) && (toIndex < 0 || fromIndex <= toIndex);
+            };
+            const codePair = ordered(route.fromCode, route.toCode);
+            const cityPair = ordered(route.fromCity, route.toCity);
+            return codePair || cityPair;
+        });
+        const officialCandidate = route && route.fromCode === "CAN" && route.toCode === "SHE" ? { title: "南航广州 → 沈阳定期班期表（官方参考）", url: "https://csair.com/h5/cn/tourism_strategy/guonei_lvyougonglve/Shenyang2/1c39mjsm7h074.shtml", snippet: "南航官方广州—沈阳班期表；可按目标日期的周几筛选班期，页面提示以官网或 APP 实时结果为准。", source: "csair.com" } : null;
+        const titleCaseSlug = (slug) => String(slug || "").replace(/(^|-)([a-z])/g, (_, separator, letter) => separator + letter.toUpperCase());
+        const travelokaPath = route ? titleCaseSlug(route.fromSlug) + "-" + titleCaseSlug(route.toSlug) + "." + route.fromCode + "." + route.toCode + "A" : "";
+        const candidates = route ? [
+            { title: "FlightConnections " + route.fromCode + " → " + route.toCode + " 航线时刻概览（待按日期确认）", url: "https://www.flightconnections.com/flights-from-" + route.fromCode.toLowerCase() + "-to-" + route.toCode.toLowerCase(), snippet: route.routeLabel + " 航线概览；页面需进一步读取目标日期。", source: "flightconnections.com" },
+            { title: "Ctrip " + route.fromCity + " → " + route.toCity + " 航班时刻表", url: "https://flights.ctrip.com/international/schedule/" + (route.fromTripCode || route.fromCode) + "-" + (route.toTripCode || route.toCode) + ".html", snippet: "航线时刻表候选来源；具体日期仍需在页面中确认。", source: "flights.ctrip.com" },
+            { title: "Airpaz " + route.fromCity + " → " + route.toCity + " 航班查询", url: "https://www.airpaz.com/zh/flight-tickets/city-city/" + route.fromSlug + "-cn-" + route.toSlug + "-cn", snippet: "可继续读取该城市对的日期航班结果。", source: "airpaz.com" },
+            { title: "Trip.com " + route.fromCity + " → " + route.toCity + " 日期航班", url: "https://www.trip.com/flights/airport-" + (route.fromTripCode || route.fromCode).toLowerCase() + "-city-" + (route.toTripCode || route.toCode).toLowerCase() + "/", snippet: "城市对页面通常包含目标日期、航司和起降时刻；若未显示航班号则仅作日期航司时刻参考。", source: "trip.com" },
+            { title: "ZborDirect " + route.fromCode + " → " + route.toCode + " 日期班期表", url: "https://zbordirect.com/en/tools/schedule?departure_city=" + route.fromCode + "&arrival_city=" + route.toCode, snippet: "按起飞和到达机场展示带日期的航班号、时刻与班期，用于补充动态 OTA 来源。", source: "zbordirect.com" },
+            { title: "Traveloka " + route.fromCity + " → " + route.toCity + " 日期航班时刻", url: "https://www.traveloka.com/zh-my/flight/route/" + travelokaPath, snippet: "按城市对展示日期标签和预定航班时刻；用于补充被拦截的 OTA 来源。", source: "traveloka.com" },
+            { title: "FlightsFrom " + route.fromCode + " → " + route.toCode + " 周班期表", url: "https://www.flightsfrom.com/" + route.fromCode + "-" + route.toCode, snippet: "路线周历与航班号时刻；需按目标日期星期核对。", source: "flightsfrom.com" },
+            ...(officialCandidate ? [officialCandidate] : []),
+        ] : [];
+        const originalRelevantCount = relevant.length;
+        const existingUrls = new Set(relevant.map((row) => String(row?.url || "").replace(/\/$/, "")));
+        for (const candidate of candidates) if (!existingUrls.has(candidate.url)) relevant.push(candidate);
+        return { ...response, results: relevant.map((row) => ({ ...row, evidenceType: "search_snippet", dateAnchored: false, exactDetailsVerified: false })), metadata: { ...(response?.metadata || {}), flightEvidencePolicy: policy, filteredIrrelevantResultCount: Math.max(0, rows.length - originalRelevantCount), injectedFlightCandidates: candidates.length } };
+    }
+`;
+  source = source.slice(0, start) + replacement + source.slice(end);
+  return Buffer.from(source + `\n/* ${marker}: generic city-pair route candidates and irrelevant-result filtering. */\n`, "utf8");
+}
+
+/**
+ * The Chinese-first Bing shortcut is useful for ordinary Chinese research, but
+ * it is a poor default for flight lookups: Bing frequently returns unrelated
+ * results for IATA/date queries while DuckDuckGo's HTML index has the actual
+ * route pages.  Keep Bing as a fallback, but let flight queries try DDG first.
+ */
+function patchFlightSearchProvider(original, archivePath) {
+  let source = original.toString("utf8");
+  if (source.includes(providerMarker)) return Buffer.from(source);
+  const anchor = `const chinaFirst = query.preferChinaRoute === true ||\n(query.preferChinaRoute !== false && (query.region === "cn" || query.region === "cn-zh" || /[\\u3400-\\u9fff]/u.test(query.query)));`;
+  if (!source.includes(anchor)) throw new Error(`${archivePath}: Chinese-first search block not found`);
+  const replacement = `${anchor}\nconst flightQuery = /(?:航班|机票|航线|起飞|到达|票价|飞行时间|机场|航空|flight|airfare|airline|airport|departure|arrival)/i.test(String(query.query || ""));`;
+  source = source.replace(anchor, replacement);
+  const guard = `if (chinaFirst) {`;
+  if (!source.includes(guard)) throw new Error(`${archivePath}: provider guard not found`);
+  source = source.replace(guard, `if (chinaFirst && !flightQuery) {`);
+  source = source.replace(`if (Date.now() < primaryUnavailableUntil)\nreturn this.searchBing(query, maxResults, requestedSearchType);`, `if (Date.now() < primaryUnavailableUntil && !flightQuery)\nreturn this.searchBing(query, maxResults, requestedSearchType);`);
+  return Buffer.from(`${source}\n/* ${providerMarker}: flight searches try DuckDuckGo before the Chinese Bing shortcut. */\n`, "utf8");
+}
+
+function patchExecutorGuidance(original, archivePath) {
+  let source = original.toString("utf8");
+  if (source.includes(marker)) return Buffer.from(source);
+  const replacements = [
+    ["concrete year/date plus PEK/SHA", "concrete year/date plus the detected city pair and IATA codes"],
+    ["injected PEK/SHA/date candidates", "injected city-pair/IATA/date candidates"],
+    ["Use web_search once for discovery; use its injected city-pair/IATA/date candidates instead of repeating generic Chinese searches.", "Use web_search for discovery and use its injected city-pair/IATA/date candidates. If every direct candidate is blocked or empty, make one additional targeted web_search using the detected IATA pair and date (maximum two searches total); do not stop solely because a host returned 403."],
+    ["Fetch or browse Airpaz/Ctrip/airline candidates directly after discovery. Use FlightConnections only for route scope unless its rendered page explicitly exposes the requested date.", "Fetch or browse the injected Airpaz/Ctrip/Trip.com/ZborDirect/airline candidates directly after discovery. Use FlightConnections only for route scope unless its rendered page explicitly exposes the requested date. If direct pages fail, use the targeted indexed-search fallback described below. A date-confirmed Trip.com row with an airline and both clock times is acceptable as 日期航司时刻参考 when no flight number is exposed; never invent a flight number."],
+    ["if (!entry?.url || ![\"web_fetch\", \"http_request\", \"browser_get_content\", \"browser_get_text\", \"browser_snapshot\"].includes(entry.tool)) return false;", "if (!entry?.url || ![\"web_search\", \"web_fetch\", \"http_request\", \"browser_get_content\", \"browser_get_text\", \"browser_snapshot\"].includes(entry.tool)) return false;"],
+    ["Only a fetched/rendered page containing the requested date, route, flight number, and time may unlock exact rows; otherwise report that the date could not be verified.", "A fetched/rendered page containing the requested date, route, flight number, and time may unlock exact rows. If a rendered Trip.com row contains the requested date, route, airline name, and both departure and arrival times but no flight number, show it only as 日期航司时刻参考 and explicitly say the flight number is not exposed. If direct pages are blocked or empty, make one targeted web_search for an indexed schedule source using the detected IATA pair and date. An indexed result may be shown only as 索引班期参考 when its snippet itself contains the requested date, route, flight number, and time; label it non-real-time and never infer prices or availability. A published weekly schedule whose weekday matches the requested date may also be shown as 班期参考; otherwise report that the date could not be verified."],
+    ["Exact rows are allowed only when one fetched/rendered page contains the requested date, route, flight number, and time. Otherwise return a concise no-verifiable-results statement with the source limitation.", "Exact rows are allowed when one fetched/rendered page contains the requested date, route, flight number, and time. If direct pages are unavailable, one targeted web_search may supply indexed date evidence; use rows only when the indexed snippet itself contains the requested date, route, flight number, and time, label them 索引班期参考, and do not claim live prices or availability. A published weekly schedule whose weekday matches the requested date may be shown as 班期参考 with a non-real-time caveat. Otherwise return a concise no-verifiable-results statement with the source limitation."],
+  ];
+  let changed = 0;
+  for (const [from, to] of replacements) if (source.includes(from)) { source = source.split(from).join(to); changed++; }
+  const v10FlightFallback = " A rendered Trip.com row with the requested date, route, named airline, and two clock values but no flight number may be shown only as 日期航司时刻参考; state that the number is not exposed and do not invent it.";
+  if (source.includes("Fetch or browse the injected Airpaz/Ctrip/ZborDirect/airline candidates directly after discovery.")) {
+    source = source.split("Fetch or browse the injected Airpaz/Ctrip/ZborDirect/airline candidates directly after discovery.").join("Fetch or browse the injected Airpaz/Ctrip/Trip.com/ZborDirect/airline candidates directly after discovery." + v10FlightFallback);
+    changed++;
+  }
+  const priorityRule = " When a Trip.com candidate is present, fetch that date-capable Trip.com page first (before route-only sites such as FlightConnections, FlightsFrom, airportoverview, or directflights); only move to another source if Trip.com is blocked or empty. Do not spend the first fetches on monthly or route-wide summaries.";
+  source = source.split("Fetch or browse one candidate directly; do not retry BCIA/FlightConnections URL variants after a 4xx, empty body, or route-only page.").join("Fetch or browse the Trip.com date candidate first when it is present; do not retry BCIA/FlightConnections URL variants after a 4xx, empty body, or route-only page." + priorityRule);
+  source = source.split("Fetch or browse the injected Airpaz/Ctrip/Trip.com/ZborDirect/airline candidates directly after discovery.").join("Fetch or browse the injected Airpaz/Ctrip/Trip.com/ZborDirect/airline candidates directly after discovery." + priorityRule);
+  source = source.split("A published weekly schedule whose weekday matches the requested date may also be shown as 班期参考;").join(v10FlightFallback + " A published weekly schedule whose weekday matches the requested date may also be shown as 班期参考;");
+  const defaultScope = "默认北京首都/大兴→上海虹桥/浦东";
+  if (source.includes(defaultScope)) {
+    source = source.split(defaultScope).join("按请求中的出发地与目的地锁定机场范围");
+    changed++;
+  }
+  const routeStart = source.indexOf("const hasRouteScope =");
+  const returnAfterRoute = source.indexOf("\nreturn hasFlightRow", routeStart);
+  const routeEnd = returnAfterRoute >= 0 ? source.lastIndexOf("})();", returnAfterRoute) : -1;
+  if (routeStart >= 0 && routeEnd > routeStart) {
+    const routeCheck = String.raw`const hasRouteScope = (() => {
+const promptText = String((this.task?.title || "") + "\n" + (this.getContractPrompt?.() || this.task?.prompt || ""));
+const cityCodes = { 北京: "PEK", 上海: "SHA", 广州: "CAN", 深圳: "SZX", 沈阳: "SHE", 成都: "CTU", 重庆: "CKG", 西安: "XIY", 杭州: "HGH", 南京: "NKG", 武汉: "WUH", 厦门: "XMN", 昆明: "KMG", 长沙: "CSX", 青岛: "TAO", 大连: "DLC", 哈尔滨: "HRB", 郑州: "CGO", 海口: "HAK", 三亚: "SYX", 天津: "TSN", 济南: "TNA", 福州: "FOC", 宁波: "NGB", 乌鲁木齐: "URC", 贵阳: "KWE", 南昌: "KHN", 合肥: "HFE", 温州: "WNZ", 兰州: "LHW", 石家庄: "SJW", 太原: "TYN", 呼和浩特: "HET", 长春: "CGQ", 桂林: "KWL", 珠海: "ZUH", 汕头: "SWA", 惠州: "HUZ", 洛阳: "LYA", 烟台: "YNT", 威海: "WEH", 徐州: "XUZ", 常州: "CZX", 南宁: "NNG", 银川: "INC", 西宁: "XNN", 拉萨: "LXA", 鄂尔多斯: "DSN", 海拉尔: "HLD", 牡丹江: "MDG", 张家界: "DYG", 宜昌: "YIH", 绵阳: "MIG", 泉州: "JJN", 黄山: "TXN", 赣州: "KOW", 香港: "HKG", 澳门: "MFM", 台北: "TPE" };
+const routeNames = Object.keys(cityCodes).filter((city) => promptText.includes(city)).slice(0, 2);
+const routeCodes = routeNames.map((city) => cityCodes[city]);
+if (routeNames.length >= 2) return routeNames.every((token) => text.includes(token)) || routeCodes.every((token) => new RegExp("\\b" + token + "\\b", "i").test(text));
+const explicitCodes = (promptText.match(/\b[A-Z]{3}\b/g) || []).slice(0, 2);
+return explicitCodes.length < 2 || explicitCodes.every((token) => new RegExp("\\b" + token + "\\b", "i").test(text));
+})();`;
+    source = source.slice(0, routeStart) + routeCheck + source.slice(routeEnd + "})();".length);
+    changed++;
+  }
+  let dateStart = source.indexOf("const dateConfirmed = dateAnchors.some");
+  if (dateStart < 0) {
+    const existingEnglishAnchors = source.indexOf("const englishDateAnchors =");
+    if (existingEnglishAnchors >= 0) dateStart = source.lastIndexOf("const targetDate = this.getRequestedFlightDate();", existingEnglishAnchors);
+  }
+  const rowStart = source.indexOf("const hasFlightRow", dateStart);
+  if (!source.includes("const dateAirlineRow") && dateStart >= 0 && rowStart > dateStart) {
+const dateCheck = String.raw`const targetDate = this.getRequestedFlightDate();
+const monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+const targetMonthName = targetDate ? monthNames[Number(targetDate.slice(5, 7)) - 1] : null;
+const targetDay = targetDate ? Number(targetDate.slice(8, 10)) : null;
+const targetMonth = targetDate ? Number(targetDate.slice(5, 7)) : null;
+const targetYear = targetDate ? targetDate.slice(0, 4) : null;
+const englishDateAnchors = targetDate && targetMonthName ? [targetMonthName + " " + targetDay, targetMonthName.slice(0, 3) + " " + targetDay, targetDay + " " + targetMonthName, targetDay + " " + targetMonthName.slice(0, 3), targetMonthName + " " + targetDay + ", " + targetYear, String(targetDay).padStart(2, "0") + "." + String(targetMonth).padStart(2, "0") + "." + targetYear.slice(2), String(targetDay).padStart(2, "0") + "/" + String(targetMonth).padStart(2, "0") + "/" + targetYear.slice(2)] : [];
+const comparableText = text.toLowerCase();
+const dateConfirmed = dateAnchors.concat(englishDateAnchors).some((anchor) => anchor && comparableText.includes(String(anchor).toLowerCase()));
+const weekday = targetDate ? new Date(targetDate + "T00:00:00").getDay() : null;
+const weekdayShort = weekday === null ? null : ["日", "一", "二", "三", "四", "五", "六"][weekday];
+const scheduleLines = text.split("\n").filter((line) => /(?:班期|每天|每日|周[一二三四五六日天]|星期[一二三四五六日天]|daily|monday|tuesday|wednesday|thursday|friday|saturday|sunday)/i.test(line)).join("\n");
+const weekdayEnglish = weekday === null ? null : ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"][weekday];
+const weekdayConfirmed = Boolean(scheduleLines) && (/(?:每天|每日|daily)/i.test(scheduleLines) || (weekdayShort && (new RegExp("(?:周|星期)" + weekdayShort).test(scheduleLines) || new RegExp("(?:^|[、,，\\s])" + weekdayShort + "(?=$|[、,，\\s])").test(scheduleLines))) || (weekdayEnglish && new RegExp("\\b" + weekdayEnglish + "\\b", "i").test(scheduleLines)));
+if (!dateConfirmed && !weekdayConfirmed) return false;
+`;
+    source = source.slice(0, dateStart) + dateCheck + source.slice(rowStart);
+    const strictFlightRow = "const hasFlightRow = /\\b[A-Z]{2}\\s?\\d{3,4}\\b/i.test(text) && /\\b\\d{1,2}:\\d{2}\\b/.test(text);";
+    const permissiveFlightRow = "const flightNumberRow = /\\b[A-Z]{2}\\s?\\d{3,4}\\b/i.test(text) && /\\b\\d{1,2}:\\d{2}\\b/.test(text); const clockValues = text.match(/\\b\\d{1,2}:\\d{2}\\b/g) || []; const dateAirlineRow = clockValues.length >= 2 && /(?:airlines?|航空|航空公司|air china|sichuan|shenzhen airlines|chengdu airlines|china southern|china eastern|normal airline|成都航空)/i.test(text); const hasFlightRow = flightNumberRow || dateAirlineRow;";
+    if (source.includes(strictFlightRow)) { source = source.replace(strictFlightRow, permissiveFlightRow); changed++; }
+    changed++;
+  }
+  if (!changed) throw new Error(`${archivePath}: fixed-route flight guards not found`);
+  return Buffer.from(source + `\n/* ${marker}: executor guidance and dated flight evidence follow the detected route. */\n`, "utf8");
+}
+
+/**
+ * Keep the post-tool answer budget when this route patch is regenerated.
+ *
+ * The route patch is sometimes run again by a separate repair/update flow.  If
+ * it writes an archive from an older base, a standalone output-length patch
+ * can otherwise be silently lost.  Applying this small, idempotent layer to
+ * the executor entries here makes the route artifact safe to install or copy.
+ */
+function patchOutputLength(original, archivePath) {
+  let source = original.toString("utf8");
+  const outputMarker = "NW_OUTPUT_LENGTH_V1";
+  if (source.includes(outputMarker)) return Buffer.from(source);
+  const replacements = [
+    [
+      "initialMaxTokens: finalizationAttempt === 0 ? 1200 : 1600",
+      "initialMaxTokens: finalizationAttempt === 0 ? 4000 : 4000",
+      "finalization initial budget",
+    ],
+    [
+      "continuationMaxTokens: finalizationAttempt === 0 ? 600 : 800",
+      "continuationMaxTokens: finalizationAttempt === 0 ? 4000 : 4000",
+      "finalization continuation budget",
+    ],
+    [
+      "t.length>4000?`${t.slice(0,4000)}...`:t",
+      "t.length>20000?`${t.slice(0,20000)}...`:t",
+      "follow-up result-summary cap",
+    ],
+    [
+      'return languageSafe.length > 4000\n? `${languageSafe.slice(0, 4000)}...`\n: languageSafe;',
+      'return languageSafe.length > 20000\n? `${languageSafe.slice(0, 20000)}...`\n: languageSafe;',
+      "regular result-summary cap",
+    ],
+  ];
+  for (const [from, to, label] of replacements) {
+    const first = source.indexOf(from);
+    const last = source.lastIndexOf(from);
+    if (first < 0 || first !== last) {
+      throw new Error(`${archivePath}: ${label}: expected exactly one match, found ${first < 0 ? 0 : "multiple"}`);
+    }
+    source = source.slice(0, first) + to + source.slice(first + from.length);
+  }
+  return Buffer.from(
+    `${source}\n/* ${outputMarker}: post-tool finalization has 4k + 4k output budget; final summaries retain up to 20k chars. */\n`,
+    "utf8",
+  );
+}
+
+function patchExecutorWithOutputLength(original, archivePath) {
+  return patchOutputLength(patchExecutorGuidance(original, archivePath), archivePath);
+}
+
+if (!fs.existsSync(sourceArchive)) throw new Error(`Source ASAR not found: ${sourceArchive}`);
+if (sourceArchive === outputArchive) throw new Error("Refusing to patch source archive in place");
+const patches = [];
+for (const runtime of runtimes) {
+  const prefix = `dist/${runtime}/electron/agent`;
+  for (const [archivePath, patcher] of [
+    [`${prefix}/executor-helpers.js`, patchExecutorHelpers],
+    [`${prefix}/tools/search-tools.js`, patchSearchTools],
+    [`${prefix}/executor.js`, patchExecutorWithOutputLength],
+    [`${prefix}/search/duckduckgo-provider.js`, patchFlightSearchProvider],
+  ]) patches.push({ archivePath, patched: patcher(asar.extractFile(sourceArchive, archivePath), archivePath) });
+}
+writeArchive(patches);
+asar.uncache(outputArchive);
+for (const patch of patches) if (!asar.extractFile(outputArchive, patch.archivePath).equals(patch.patched)) throw new Error(`Post-write verification failed: ${patch.archivePath}`);
+console.log(JSON.stringify({ sourceArchive, outputArchive, patchedEntries: patches.length, marker }, null, 2));

--- a/scripts/patch_neoworker_output_length_v1.mjs
+++ b/scripts/patch_neoworker_output_length_v1.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+
+/**
+ * Give tool-free finalization enough room to finish a user-facing answer.
+ *
+ * The normal tool loop has its own adaptive budgets.  This patch is deliberately
+ * scoped to the post-tool finalization turn that previously used 1200 + 600
+ * output tokens, and to the task result-summary cap that copied that answer.
+ * It does not change tool-call budgets or renderer preview truncation rules.
+ */
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const asar = require("@electron/asar");
+const { Pickle } = require("@electron/asar/lib/pickle");
+
+const sourceArchive = path.resolve(
+  process.argv[2] ?? "/Applications/NeoWorker.app/Contents/Resources/app.asar",
+);
+const outputArchive = path.resolve(
+  process.argv[3] ?? ".novaready/package-output/app.asar.output-length-v1",
+);
+const marker = "NW_OUTPUT_LENGTH_V1";
+const runtimes = ["electron", "daemon", "cli"];
+
+const sha256 = (value) => crypto.createHash("sha256").update(value).digest("hex");
+
+function collectPackedEntries(node, prefix = "", result = []) {
+  for (const [name, entry] of Object.entries(node.files ?? {})) {
+    const archivePath = prefix ? `${prefix}/${name}` : name;
+    if (entry.files) collectPackedEntries(entry, archivePath, result);
+    else if (!entry.unpacked && entry.offset !== undefined) {
+      result.push({
+        archivePath,
+        entry,
+        oldOffset: Number(entry.offset),
+        oldSize: Number(entry.size),
+      });
+    }
+  }
+  return result;
+}
+
+function updateIntegrity(entry, content) {
+  if (!entry.integrity) return;
+  if (entry.integrity.algorithm !== "SHA256") {
+    throw new Error(`Unsupported ASAR integrity algorithm for ${entry.name ?? "entry"}`);
+  }
+  entry.integrity.hash = sha256(content);
+  if (!Array.isArray(entry.integrity.blocks)) return;
+  const blockSize = Number(entry.integrity.blockSize || content.length || 1);
+  entry.integrity.blocks = [];
+  for (let offset = 0; offset < content.length; offset += blockSize) {
+    entry.integrity.blocks.push(
+      sha256(content.subarray(offset, Math.min(content.length, offset + blockSize))),
+    );
+  }
+  if (!entry.integrity.blocks.length) entry.integrity.blocks.push(sha256(content));
+}
+
+function replaceExactlyOnce(source, from, to, label) {
+  const first = source.indexOf(from);
+  const last = source.lastIndexOf(from);
+  if (first < 0 || first !== last) {
+    throw new Error(`${label}: expected exactly one match, found ${first < 0 ? 0 : "multiple"}`);
+  }
+  return source.slice(0, first) + to + source.slice(first + from.length);
+}
+
+function patchExecutor(original, archivePath) {
+  let source = original.toString("utf8");
+  if (source.includes(marker)) return original;
+
+  source = replaceExactlyOnce(
+    source,
+    "initialMaxTokens: finalizationAttempt === 0 ? 1200 : 1600",
+    "initialMaxTokens: finalizationAttempt === 0 ? 4000 : 4000",
+    `${archivePath}: finalization initial budget`,
+  );
+  source = replaceExactlyOnce(
+    source,
+    "continuationMaxTokens: finalizationAttempt === 0 ? 600 : 800",
+    "continuationMaxTokens: finalizationAttempt === 0 ? 4000 : 4000",
+    `${archivePath}: finalization continuation budget`,
+  );
+  source = replaceExactlyOnce(
+    source,
+    "t.length>4000?`${t.slice(0,4000)}...`:t",
+    "t.length>20000?`${t.slice(0,20000)}...`:t",
+    `${archivePath}: follow-up result-summary cap`,
+  );
+  source = replaceExactlyOnce(
+    source,
+    'return languageSafe.length > 4000\n? `${languageSafe.slice(0, 4000)}...`\n: languageSafe;',
+    'return languageSafe.length > 20000\n? `${languageSafe.slice(0, 20000)}...`\n: languageSafe;',
+    `${archivePath}: regular result-summary cap`,
+  );
+
+  return Buffer.from(
+    `${source}\n/* ${marker}: post-tool finalization has 4k + 4k output budget; final summaries retain up to 20k chars. */\n`,
+    "utf8",
+  );
+}
+
+function writeArchive(patches) {
+  const rawHeader = asar.getRawHeader(sourceArchive);
+  const entries = collectPackedEntries(rawHeader.header).sort((a, b) => a.oldOffset - b.oldOffset);
+  const patchMap = new Map(patches.map((patch) => [patch.archivePath, patch.content]));
+  const found = new Set();
+  let nextOffset = 0;
+  for (const item of entries) {
+    item.entry.offset = String(nextOffset);
+    const replacement = patchMap.get(item.archivePath);
+    if (replacement) {
+      found.add(item.archivePath);
+      item.entry.size = replacement.length;
+      updateIntegrity(item.entry, replacement);
+    }
+    nextOffset += Number(item.entry.size);
+  }
+  for (const patch of patches) {
+    if (!found.has(patch.archivePath)) {
+      throw new Error(`Patched entry is not packed: ${patch.archivePath}`);
+    }
+  }
+
+  const headerPickle = Pickle.createEmpty();
+  headerPickle.writeString(JSON.stringify(rawHeader.header));
+  const headerBuffer = headerPickle.toBuffer();
+  const sizePickle = Pickle.createEmpty();
+  sizePickle.writeUInt32(headerBuffer.length);
+  const sizeBuffer = sizePickle.toBuffer();
+  if (sizeBuffer.length !== 8) throw new Error("Unexpected ASAR size header length");
+
+  fs.mkdirSync(path.dirname(outputArchive), { recursive: true });
+  if (fs.existsSync(outputArchive)) fs.unlinkSync(outputArchive);
+  const sourceFd = fs.openSync(sourceArchive, "r");
+  const outputFd = fs.openSync(outputArchive, "wx");
+  const sourceDataStart = rawHeader.headerSize + 8;
+  const copyBuffer = Buffer.allocUnsafe(4 * 1024 * 1024);
+  try {
+    fs.writeSync(outputFd, sizeBuffer);
+    fs.writeSync(outputFd, headerBuffer);
+    for (const item of entries) {
+      const replacement = patchMap.get(item.archivePath);
+      if (replacement) {
+        fs.writeSync(outputFd, replacement);
+        continue;
+      }
+      let remaining = item.oldSize;
+      let sourcePosition = sourceDataStart + item.oldOffset;
+      while (remaining > 0) {
+        const count = Math.min(copyBuffer.length, remaining);
+        const bytesRead = fs.readSync(sourceFd, copyBuffer, 0, count, sourcePosition);
+        if (bytesRead !== count) throw new Error(`Short read for ${item.archivePath}`);
+        fs.writeSync(outputFd, copyBuffer, 0, bytesRead);
+        sourcePosition += bytesRead;
+        remaining -= bytesRead;
+      }
+    }
+    fs.fsyncSync(outputFd);
+  } finally {
+    fs.closeSync(sourceFd);
+    fs.closeSync(outputFd);
+  }
+}
+
+if (!fs.existsSync(sourceArchive)) throw new Error(`Source ASAR not found: ${sourceArchive}`);
+if (sourceArchive === outputArchive) throw new Error("Refusing to patch source ASAR in place");
+
+const rawHeader = asar.getRawHeader(sourceArchive);
+const patches = [];
+for (const runtime of runtimes) {
+  const archivePath = `dist/${runtime}/electron/agent/executor.js`;
+  patches.push({
+    archivePath,
+    content: patchExecutor(asar.extractFile(sourceArchive, archivePath), archivePath),
+  });
+}
+
+writeArchive(patches);
+asar.uncache(outputArchive);
+for (const patch of patches) {
+  const roundTrip = asar.extractFile(outputArchive, patch.archivePath);
+  if (!roundTrip.equals(patch.content) || !roundTrip.toString("utf8").includes(marker)) {
+    throw new Error(`Post-write verification failed: ${patch.archivePath}`);
+  }
+}
+
+console.log(JSON.stringify({
+  sourceArchive,
+  outputArchive,
+  marker,
+  patchedEntries: patches.length,
+  archiveSha256: sha256(fs.readFileSync(outputArchive)),
+}, null, 2));

--- a/scripts/test_neoworker_auto_update.mjs
+++ b/scripts/test_neoworker_auto_update.mjs
@@ -1,0 +1,200 @@
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import path from 'node:path';
+import vm from 'node:vm';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const asar = require('@electron/asar');
+const archive = path.resolve(
+  process.argv[2] ?? '.novaready/package-output/app.auto-update.asar',
+);
+
+const paths = {
+  main: 'dist/electron/electron/main.js',
+  handlers: 'dist/electron/electron/ipc/handlers.js',
+  updater: 'dist/electron/electron/updater/update-manager.js',
+  preload: 'dist/electron/electron/preload.js',
+  renderer: 'dist/renderer/assets/index-BTC5MTVk.js',
+  css: 'dist/renderer/assets/index-DuUtsx0I.css',
+};
+
+function source(archivePath) {
+  return asar.extractFile(archive, archivePath).toString('utf8').trimEnd();
+}
+
+function sha256(buffer) {
+  return crypto.createHash('sha256').update(buffer).digest('hex');
+}
+
+function archiveEntry(rawHeader, archivePath) {
+  let entry = rawHeader.header;
+  for (const segment of archivePath.split('/')) {
+    entry = entry?.files?.[segment];
+    if (!entry) throw new Error(`Missing ASAR entry: ${archivePath}`);
+  }
+  return entry;
+}
+
+const main = source(paths.main);
+const handlers = source(paths.handlers);
+const updater = source(paths.updater);
+const preload = source(paths.preload);
+const renderer = source(paths.renderer);
+const css = source(paths.css);
+
+assert.match(main, /require\("\.\/updater"\)\.updateManager\.setMainWindow\(mainWindow\)/);
+for (const handler of [
+  'APP_GET_VERSION',
+  'APP_CHECK_UPDATES',
+  'APP_DOWNLOAD_UPDATE',
+  'APP_INSTALL_UPDATE',
+]) {
+  assert.match(handlers, new RegExp(`ipcMain\\.handle\\(types_1\\.IPC_CHANNELS\\.${handler}`));
+}
+assert.doesNotMatch(main, /nwUpdateManager\.downloadAndInstallUpdate/);
+
+assert.match(updater, /repoOwner="Yuan-lab-LLM"/);
+assert.doesNotMatch(updater, /repoOwner="NeoWorker"/);
+assert.match(updater, /releases\/download\//);
+assert.match(updater, /sha256:\(\[a-f0-9\]\{64\}\)/);
+assert.match(updater, /asset\.url\.startsWith\(this\.assetUrlPrefix\(\)\)/);
+assert.match(updater, /apiUrl:typeof asset\.url/);
+assert.match(updater, /await this\.downloadManualAsset\(info\)/);
+assert.match(updater, /AbortController/);
+assert.match(updater, /更新下载超时（45秒无数据）/);
+assert.match(updater, /autoDownload=false/);
+assert.match(updater, /autoInstallOnAppQuit=true/);
+assert.match(updater, /allowPrerelease=false/);
+assert.match(updater, /quitAndInstall\(false,true\)/);
+
+for (const api of [
+  'checkForUpdates',
+  'downloadUpdate',
+  'installUpdate',
+  'onUpdateProgress',
+  'onUpdateDownloaded',
+  'onUpdateError',
+]) {
+  assert.match(preload, new RegExp(`${api}:`));
+}
+
+assert.match(renderer, /const\[NWUpdate,NWSetUpdate\]/);
+assert.match(renderer, /sidebar\.update\.checking/);
+assert.match(renderer, /setTimeout\(pe,8e3\)/);
+assert.match(renderer, /setInterval\(pe,216e5\)/);
+assert.match(renderer, /window\.electronAPI\.downloadUpdate\(NWUpdate\)/);
+assert.match(renderer, /window\.electronAPI\.installUpdate\(\)/);
+assert.match(renderer, /NWUpdate\?"\[update\]":"\[guide\]"/);
+assert.match(renderer, /NWUpdate\?NWLabel:O\("sidebar\.setupWizard","Setup Guide"\)/);
+assert.doesNotMatch(renderer, /q\?\.available&&!ie&&h\.jsxs\("div",\{className:"sidebar-update-slot"/);
+assert.match(css, /\.nw-update-btn\{/);
+assert.match(css, /border-radius:999px/);
+assert.match(css, /color-mix\(in srgb,var\(--color-brand-blue,#1e8df6\) 78%,#000\)/);
+assert.doesNotMatch(css, /\.sidebar-update-actions\{/);
+
+const ipcChannels = {
+  APP_UPDATE_PROGRESS: 'app:updateProgress',
+  APP_UPDATE_ERROR: 'app:updateError',
+  APP_UPDATE_DOWNLOADED: 'app:updateDownloaded',
+};
+let currentVersion = '0.1.0';
+let release = {
+  tag_name: 'v0.1.1',
+  draft: false,
+  prerelease: false,
+  body: 'Test release',
+  html_url: 'https://github.com/Yuan-lab-LLM/NeoWorker/releases/tag/v0.1.1',
+  published_at: '2026-08-26T00:00:00Z',
+  assets: [
+    {
+      name: 'NeoWorker-0.1.1-arm64.dmg',
+      browser_download_url:
+        'https://github.com/Yuan-lab-LLM/NeoWorker/releases/download/v0.1.1/NeoWorker-0.1.1-arm64.dmg',
+      size: 123,
+      digest: `sha256:${'a'.repeat(64)}`,
+    },
+    {
+      name: '../../untrusted.dmg',
+      browser_download_url: 'https://attacker.invalid/untrusted.dmg',
+      size: 1,
+    },
+  ],
+};
+const sent = [];
+const electronMock = {
+  app: {
+    getVersion: () => currentVersion,
+    isPackaged: true,
+    getPath: () => '/tmp',
+  },
+  net: {
+    fetch: async () => ({
+      ok: true,
+      status: 200,
+      json: async () => release,
+    }),
+  },
+  shell: { openPath: async () => '' },
+};
+const moduleMock = { exports: {} };
+const updateContext = vm.createContext({
+  Buffer,
+  console,
+  exports: moduleMock.exports,
+  module: moduleMock,
+  process,
+  require(specifier) {
+    if (specifier === 'electron') return electronMock;
+    if (specifier === '../../shared/types') return { IPC_CHANNELS: ipcChannels };
+    return require(specifier);
+  },
+});
+vm.runInContext(updater, updateContext, { filename: paths.updater });
+const manager = moduleMock.exports.updateManager;
+manager.setMainWindow({
+  isDestroyed: () => false,
+  webContents: { send: (channel, payload) => sent.push({ channel, payload }) },
+});
+
+const available = await manager.checkForUpdates();
+assert.equal(available.available, true);
+assert.equal(available.currentVersion, '0.1.0');
+assert.equal(available.latestVersion, '0.1.1');
+assert.equal(available.assets.length, 1, 'untrusted release assets must be discarded');
+assert.equal(manager.pickManualAsset(available).name, 'NeoWorker-0.1.1-arm64.dmg');
+assert.equal(manager.hasUpdaterMetadata(available), false);
+assert.ok(sent.some((event) => event.channel === ipcChannels.APP_UPDATE_PROGRESS));
+
+currentVersion = '0.1.1';
+const current = await manager.checkForUpdates();
+assert.equal(current.available, false);
+assert.equal(manager.latestUpdate, null);
+
+release = { ...release, tag_name: 'not-a-semver' };
+await assert.rejects(manager.checkForUpdates(), /版本号格式无效/);
+
+const rawHeader = asar.getRawHeader(archive);
+for (const archivePath of Object.values(paths)) {
+  const buffer = asar.extractFile(archive, archivePath);
+  const entry = archiveEntry(rawHeader, archivePath);
+  const digest = sha256(buffer);
+  assert.equal(entry.integrity?.hash, digest);
+  assert.equal(entry.integrity?.blocks?.[0], digest);
+}
+
+console.log(JSON.stringify({
+  archive,
+  status: 'passed',
+  coverage: [
+    'GitHub release detection and semantic version comparison',
+    'trusted release asset filtering',
+    'platform-specific installer selection',
+    'main-process IPC registration',
+    'preload API exposure',
+    'delayed and periodic sidebar checks',
+    'setup-guide/update-button state switch',
+    'download, progress, open-installer, and restart states',
+    'ASAR integrity metadata',
+  ],
+}, null, 2));

--- a/scripts/test_neoworker_flight_route_general_v3.mjs
+++ b/scripts/test_neoworker_flight_route_general_v3.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import vm from "node:vm";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const asar = require("@electron/asar");
+const archive = process.argv[2] || ".novaready/package-output/app.asar.flight-route-general-v14";
+const runtimes = ["electron", "daemon", "cli"];
+const marker = /NW_FLIGHT_ROUTE_GENERAL_V(?:[3-9]|10|11|12|13|14)/;
+
+function extract(runtime, file) {
+  return asar.extractFile(archive, `dist/${runtime}/electron/agent/${file}`).toString("utf8");
+}
+
+function loadHelpers(source) {
+  const module = { exports: {} };
+  vm.runInNewContext(source, {
+    module,
+    exports: module.exports,
+    require: (id) => id === "path" ? require("node:path") : id === "crypto" ? require("node:crypto") : { canonicalizeToolName: (name) => name },
+    console,
+    URL,
+    Date,
+    setTimeout,
+    clearTimeout,
+  }, { filename: "executor-helpers.js" });
+  return module.exports;
+}
+
+for (const runtime of runtimes) {
+  const helpersSource = extract(runtime, "executor-helpers.js");
+  assert.match(helpersSource, marker);
+  const helperApi = loadHelpers(helpersSource);
+  const queries = [];
+  await helperApi.runDuckDuckGoResearch({ query: "查一下9月5日广州飞沈阳的航班信息", maxResults: 4 }, async ({ query }) => {
+    queries.push(query);
+    return { results: [{ title: query, url: "https://example.test/flight", snippet: "flight result" }] };
+  });
+  assert.ok(queries.some((query) => /2026-09-05/.test(query) && /CAN/.test(query) && /SHE/.test(query)), `${runtime}: Guangzhou-Shenyang date/IATA expansion missing`);
+  const otherQueries = [];
+  await helperApi.runDuckDuckGoResearch({ query: "查一下9月10日成都飞深圳的航班信息", maxResults: 4 }, async ({ query }) => {
+    otherQueries.push(query);
+    return { results: [{ title: query, url: "https://example.test/flight", snippet: "flight result" }] };
+  });
+  assert.ok(otherQueries.some((query) => /2026-09-10/.test(query) && /CTU/.test(query) && /SZX/.test(query)), `${runtime}: Chengdu-Shenzhen date/IATA expansion missing`);
+  assert.ok(otherQueries.some((query) => /site:zbordirect\.com/.test(query)), `${runtime}: targeted indexed schedule query missing`);
+  assert.ok(otherQueries.every((query) => !/PEK\s+SHA/.test(query)), `${runtime}: route expansion still falls back to Beijing-Shanghai`);
+
+  const searchToolsSource = extract(runtime, "tools/search-tools.js");
+  assert.match(searchToolsSource, /extractFlightRouteCodes/);
+  assert.match(searchToolsSource, /flightconnections\.com\/flights-from-/);
+  assert.match(searchToolsSource, /route\.fromCode \+ "-" \+ route\.toCode/);
+  assert.match(searchToolsSource, /route\.fromSlug \+ "-cn-" \+ route\.toSlug/);
+  assert.match(searchToolsSource, /zbordirect\.com\/en\/tools\/schedule/);
+  assert.match(searchToolsSource, /trip\.com\/flights\/airport-/);
+  assert.match(searchToolsSource, /const codePair/);
+  assert.match(searchToolsSource, /const ordered/);
+  assert.match(searchToolsSource, /tripCityCodes/);
+  assert.match(searchToolsSource, /SIA/);
+  assert.match(searchToolsSource, /csair\.com\/h5\/cn\/tourism_strategy/);
+
+  const providerSource = extract(runtime, "search/duckduckgo-provider.js");
+  assert.match(providerSource, /NW_FLIGHT_SEARCH_PROVIDER_V1/);
+  assert.match(providerSource, /chinaFirst && !flightQuery/);
+
+  const executorSource = extract(runtime, "executor.js");
+  assert.match(executorSource, /NW_OUTPUT_LENGTH_V1/);
+  assert.match(executorSource, /initialMaxTokens: finalizationAttempt === 0 \? 4000 : 4000/);
+  assert.match(executorSource, /continuationMaxTokens: finalizationAttempt === 0 \? 4000 : 4000/);
+  assert.doesNotMatch(executorSource, /initialMaxTokens: finalizationAttempt === 0 \? 1200 : 1600/);
+  assert.match(executorSource, /detected city pair and IATA codes/);
+  assert.match(executorSource, /city-pair\/IATA\/date candidates/);
+  assert.match(executorSource, /weekdayConfirmed/);
+  assert.match(executorSource, /englishDateAnchors/);
+  assert.match(executorSource, /targeted web_search/);
+  assert.match(executorSource, /\["web_search", "web_fetch"/);
+  assert.match(executorSource, /targetDay \+ " " \+ targetMonthName/);
+  assert.match(executorSource, /routeNames/);
+  assert.match(executorSource, /dateAirlineRow/);
+  assert.match(executorSource, /Trip\.com date candidate first/);
+  const methodStart = executorSource.indexOf("isFlightInfoTask() {");
+  const methodEnd = executorSource.indexOf("taskRequiresTodayContext() {", methodStart);
+  assert.ok(methodStart >= 0 && methodEnd > methodStart, `${runtime}: flight evidence method boundaries`);
+  const vmContext = vm.createContext({ Date, String, Array, RegExp, Number });
+  new vm.Script("class FlightHarness {" + executorSource.slice(methodStart, methodEnd) + "}; this.FlightHarness = FlightHarness;").runInContext(vmContext);
+  const FlightHarness = vmContext.FlightHarness;
+  const harness = new FlightHarness();
+  harness.task = { title: "", prompt: "查一下2026年9月6日成都飞深圳的航班信息" };
+  harness.getContractPrompt = () => harness.task.prompt;
+  harness.webEvidenceMemory = [{ tool: "web_fetch", url: "https://www.trip.com/flights/airport-ctu-city-szx/", evidenceText: "2026年9月6日 成都（CTU）→ 深圳（SZX） 成都航空 07:55 10:30" }];
+  assert.equal(harness.hasDatedFetchedFlightEvidence(), true, `${runtime}: dated airline/time row should unlock reference output`);
+}
+
+console.log(JSON.stringify({ archive, runtimes: runtimes.length, passed: true, marker: "NW_FLIGHT_ROUTE_GENERAL_V13" }, null, 2));

--- a/scripts/test_neoworker_output_length_v1.mjs
+++ b/scripts/test_neoworker_output_length_v1.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const asar = require("@electron/asar");
+const archive = path.resolve(
+  process.argv[2] ?? ".novaready/package-output/app.asar.output-length-v1",
+);
+const marker = "NW_OUTPUT_LENGTH_V1";
+const runtimes = ["electron", "daemon", "cli"];
+
+assert.ok(fs.existsSync(archive), `Archive not found: ${archive}`);
+
+function extract(archivePath) {
+  return asar.extractFile(archive, archivePath).toString("utf8");
+}
+
+for (const runtime of runtimes) {
+  const archivePath = `dist/${runtime}/electron/agent/executor.js`;
+  const source = extract(archivePath);
+  assert.ok(source.includes(marker), `${archivePath}: marker missing`);
+  assert.ok(
+    source.includes("initialMaxTokens: finalizationAttempt === 0 ? 4000 : 4000"),
+    `${archivePath}: finalization initial budget was not raised`,
+  );
+  assert.ok(
+    source.includes("continuationMaxTokens: finalizationAttempt === 0 ? 4000 : 4000"),
+    `${archivePath}: finalization continuation budget was not raised`,
+  );
+  assert.ok(
+    source.includes("t.length>20000?`${t.slice(0,20000)}...`:t"),
+    `${archivePath}: follow-up result-summary cap was not raised`,
+  );
+  assert.ok(
+    source.includes('return languageSafe.length > 20000\n? `${languageSafe.slice(0, 20000)}...`\n: languageSafe;'),
+    `${archivePath}: regular result-summary cap was not raised`,
+  );
+  assert.ok(
+    !source.includes("initialMaxTokens: finalizationAttempt === 0 ? 1200 : 1600"),
+    `${archivePath}: old finalization budget is still present`,
+  );
+  assert.ok(
+    !source.includes("continuationMaxTokens: finalizationAttempt === 0 ? 600 : 800"),
+    `${archivePath}: old continuation budget is still present`,
+  );
+}
+
+console.log(JSON.stringify({
+  ok: true,
+  archive,
+  runtimesChecked: runtimes.length,
+  behaviors: [
+    "post-tool finalization has a 4000-token initial budget",
+    "post-tool finalization has a 4000-token continuation budget",
+    "regular and follow-up task summaries retain up to 20000 characters",
+    "tool-call and renderer preview caps remain untouched",
+  ],
+}, null, 2));


### PR DESCRIPTION
## Summary
- add packaged-runtime patch for longer post-tool final answers and retained summaries
- generalize flight-route/IATA lookup and source fallbacks
- harden the GitHub auto-update download, integrity, progress, and restart paths
- add regression coverage for all three areas

## Validation
- `node scripts/test_neoworker_output_length_v1.mjs /Applications/NeoWorker.app/Contents/Resources/app.asar`
- `node scripts/test_neoworker_flight_route_general_v3.mjs /Applications/NeoWorker.app/Contents/Resources/app.asar`
- `node scripts/test_neoworker_auto_update.mjs /Applications/NeoWorker.app/Contents/Resources/app.asar`
- `node --check` on all six added scripts

All packaged-runtime regression checks passed locally.