### PR TITLE
release: prepare v0.1.3 metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ NeoWorker focuses on turning AI from a conversational assistant into a personal 
 
 ## Current version
 
-The current public version is **<code>v0.1.2</code>** (package version <code>0.1.2</code>). The GitHub Release includes:
+The current public version is **<code>v0.1.3</code>** (package version <code>0.1.3</code>). The GitHub Release includes:
 
 - a macOS Apple Silicon <code>.dmg</code> package
 - a Windows <code>.exe</code> installer
@@ -103,8 +103,8 @@ Download NeoWorker only from the official [GitHub Releases](https://github.com/Y
 
 | Platform | Package | Installation |
 | --- | --- | --- |
-| **macOS (Apple Silicon)** | <code>NeoWorker-0.1.2-arm64.dmg</code> | Open the disk image and drag NeoWorker into Applications. |
-| **Windows (x64)** | <code>NeoWorker-0.1.2-windows-x64-setup.exe</code> | Run the installer and follow the setup prompts. |
+| **macOS (Apple Silicon)** | <code>NeoWorker-0.1.3-arm64.dmg</code> | Open the disk image and drag NeoWorker into Applications. |
+| **Windows (x64)** | <code>NeoWorker-0.1.3-windows-x64-setup.exe</code> | Run the installer and follow the setup prompts. |
 | **Checksums** | <code>latest-mac.yml</code> / <code>latest.yml</code> | Verify the downloaded installer before opening it. |
 
 #### Verify the download
@@ -114,20 +114,20 @@ Download the checksum manifest from the same Release, calculate the installer ch
 On macOS:
 
 ~~~bash
-shasum -a 256 NeoWorker-0.1.2-arm64.dmg
+shasum -a 256 NeoWorker-0.1.3-arm64.dmg
 ~~~
 
 On Windows PowerShell:
 
 ~~~powershell
-Get-FileHash .\NeoWorker-0.1.2-windows-x64-setup.exe -Algorithm SHA256
+Get-FileHash .\NeoWorker-0.1.3-windows-x64-setup.exe -Algorithm SHA256
 ~~~
 
 #### Install on macOS
 
-NeoWorker v0.1.2 for macOS is an unsigned Apple Silicon build. The first launch may therefore need a one-time Gatekeeper approval for this app.
+NeoWorker v0.1.3 for macOS is an unsigned Apple Silicon build. The first launch may therefore need a one-time Gatekeeper approval for this app.
 
-1. Download <code>NeoWorker-0.1.2-arm64.dmg</code> from the official [NeoWorker Releases](https://github.com/Yuan-lab-LLM/NeoWorker/releases/latest) page.
+1. Download <code>NeoWorker-0.1.3-arm64.dmg</code> from the official [NeoWorker Releases](https://github.com/Yuan-lab-LLM/NeoWorker/releases/latest) page.
 2. Open the downloaded disk image, then drag **NeoWorker** into **Applications**.
 
    <p align="left">
@@ -176,7 +176,7 @@ If macOS says NeoWorker **will damage your computer**, do not bypass that warnin
 
 #### Install on Windows
 
-1. Download <code>NeoWorker-0.1.2-windows-x64-setup.exe</code> from the official [NeoWorker Releases](https://github.com/Yuan-lab-LLM/NeoWorker/releases/latest) page.
+1. Download <code>NeoWorker-0.1.3-windows-x64-setup.exe</code> from the official [NeoWorker Releases](https://github.com/Yuan-lab-LLM/NeoWorker/releases/latest) page.
 2. Double-click the installer and follow the setup prompts.
 3. If Windows SmartScreen displays **Windows protected your PC**, confirm that the file name is the NeoWorker installer from this Release, click **More info**, then click **Run anyway**.
 4. Finish setup and launch **NeoWorker** from the Start menu or desktop shortcut.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-09-03
+
+### Fixed
+
+- Increased the post-tool finalization budget and retained-result summary limit so long analysis answers are not cut off prematurely.
+- Generalized flight lookup routing to infer city pairs, IATA codes, dates, and reliable indexed sources instead of falling back to a fixed Beijing–Shanghai route.
+- Hardened GitHub update downloads with trusted asset filtering, streaming progress, checksum verification, timeout handling, and a clear manual-install fallback.
+- Added packaged-runtime patch and regression-test scripts covering the three fixes above.
+
 ## [0.1.2] - 2026-09-03
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neoworker",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neoworker",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "bundleDependencies": [
         "@earendil-works/pi-ai",
         "@mariozechner/pi-ai",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neoworker",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "NeoWorker - GUI-first, CLI-capable local AI super app and everything app for coding, email, agents, documents, spreadsheets, presentations, web design, automations, and agentic work",
   "main": "dist/electron/electron/main.js",
   "author": "Yuan-lab-LLM",
@@ -70,6 +70,7 @@
     "office:release-gate": "npm run build:electron && node scripts/qa/office-artifact-release-gate.cjs",
     "skills:validate-routing": "node scripts/qa/validate-skills-routing.mjs",
     "skills:validate-content": "node scripts/qa/validate-skills-content.mjs",
+    "qa:eval:enforce-regressions": "node scripts/qa/enforce_eval_regression_policy.cjs",
     "lint": "oxlint --config config/oxlint.json src tests",
     "type-check": "tsc --noEmit -p tsconfig.json",
     "test": "vitest --config config/vitest.config.ts run",

--- a/src/shared/product-brand.ts
+++ b/src/shared/product-brand.ts
@@ -1,3 +1,3 @@
 export const PRODUCT_NAME = "NeoWorker";
-export const PRODUCT_SEMVER = "0.1.2";
-export const PRODUCT_DISPLAY_VERSION = "V0.1.2";
+export const PRODUCT_SEMVER = "0.1.3";
+export const PRODUCT_DISPLAY_VERSION = "V0.1.3";


### PR DESCRIPTION
## Summary
- bump package and product display versions to 0.1.3
- document the latest runtime fixes in the changelog and README
- add the CI regression-policy script entry expected by the pull-request workflow

This metadata commit is required because tag v0.1.3 must match package.json before the release workflow can build artifacts.