### PR TITLE
Fix in-app version badge drift

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-09-03
+
+### Fixed
+
+- Kept the in-app version badge synchronized with the packaged application version so the UI no longer reports the previous release after an update.
+
 ## [0.1.4] - 2026-09-03
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neoworker",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neoworker",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "bundleDependencies": [
         "@earendil-works/pi-ai",
         "@mariozechner/pi-ai",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neoworker",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "NeoWorker - GUI-first, CLI-capable local AI super app and everything app for coding, email, agents, documents, spreadsheets, presentations, web design, automations, and agentic work",
   "main": "dist/electron/electron/main.js",
   "author": "Yuan-lab-LLM",

--- a/src/shared/__tests__/product-brand.test.ts
+++ b/src/shared/__tests__/product-brand.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { PRODUCT_DISPLAY_VERSION, PRODUCT_SEMVER } from "../product-brand";
+
+describe("product branding", () => {
+  it("stays synchronized with the package version used for releases", () => {
+    const packageJson = JSON.parse(
+      readFileSync(resolve(process.cwd(), "package.json"), "utf8"),
+    ) as { version?: unknown };
+
+    expect(packageJson.version).toBe(PRODUCT_SEMVER);
+    expect(PRODUCT_DISPLAY_VERSION).toBe(`V${packageJson.version}`);
+  });
+});

--- a/src/shared/product-brand.ts
+++ b/src/shared/product-brand.ts
@@ -1,3 +1,3 @@
 export const PRODUCT_NAME = "NeoWorker";
-export const PRODUCT_SEMVER = "0.1.3";
-export const PRODUCT_DISPLAY_VERSION = "V0.1.3";
+export const PRODUCT_SEMVER = "0.1.5";
+export const PRODUCT_DISPLAY_VERSION = `V${PRODUCT_SEMVER}`;


### PR DESCRIPTION
## Problem
The v0.1.4 package metadata was correct, but the renderer still displayed V0.1.3 because src/shared/product-brand.ts was not updated.

## Fix
- Align product semver/display version with package version 0.1.5.
- Derive display version from the semver constant.
- Add a regression test that compares product branding with package.json.

## Validation
- Product branding Vitest: 1 passed.
- git diff --check passed.