### PR TITLE
feat: ship focused homepage agent hub

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6] - 2026-09-03
+
+### Added
+
+- Restored the focused task-first welcome surface as the default desktop entry point.
+- Added a localized recommended-agent hub with portraits, role-aware composer shortcuts, and a direct link to agent management.
+- Added responsive layout and regression coverage so the agent hub and quick-start actions remain visible together on smaller windows.
+
 ## [0.1.5] - 2026-09-03
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neoworker",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neoworker",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "bundleDependencies": [
         "@earendil-works/pi-ai",
         "@mariozechner/pi-ai",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neoworker",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "NeoWorker - GUI-first, CLI-capable local AI super app and everything app for coding, email, agents, documents, spreadsheets, presentations, web design, automations, and agentic work",
   "main": "dist/electron/electron/main.js",
   "author": "Yuan-lab-LLM",

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1022,6 +1022,7 @@ type SelectedTaskWorkspaceViewProps = {
   onChangeWorkspace: () => void;
   onSelectWorkspace: (workspace: Workspace) => void;
   onOpenSettings: (tab?: string) => void;
+  onOpenAgentManagement: () => void;
   onStopTask: () => Promise<void>;
   onEnableShellForPausedTask: () => Promise<void>;
   onContinueWithoutShellForPausedTask: () => Promise<void>;
@@ -1151,6 +1152,7 @@ const SelectedTaskWorkspaceView = memo(
     onChangeWorkspace,
     onSelectWorkspace,
     onOpenSettings,
+    onOpenAgentManagement,
     onStopTask,
     onEnableShellForPausedTask,
     onContinueWithoutShellForPausedTask,
@@ -1949,6 +1951,7 @@ const SelectedTaskWorkspaceView = memo(
               onChangeWorkspace={onChangeWorkspace}
               onSelectWorkspace={onSelectWorkspace}
               onOpenSettings={onOpenSettings as Any}
+              onOpenAgentManagement={onOpenAgentManagement}
               onStopTask={onStopTask}
               onEnableShellForPausedTask={onEnableShellForPausedTask}
               onContinueWithoutShellForPausedTask={
@@ -2226,6 +2229,7 @@ const SelectedTaskWorkspaceView = memo(
     prev.sideChat === next.sideChat &&
     prev.rightPanelInput === next.rightPanelInput &&
     prev.onArtifactFocusChange === next.onArtifactFocusChange &&
+    prev.onOpenAgentManagement === next.onOpenAgentManagement &&
     prev.onToggleRightSidebar === next.onToggleRightSidebar,
 );
 
@@ -2477,14 +2481,14 @@ export function App() {
   const [remoteTaskView, setRemoteTaskView] = useState<RemoteTaskView | null>(
     null,
   );
-  // The workspace dashboard is the first-run landing surface.  Starting in
-  // the chat/task view made a fresh install look like the legacy interface
-  // even though the newer dashboard was already bundled in the release.
-  const [currentView, setCurrentView] = useState<AppView>("home");
+  // Start in the focused welcome surface so a fresh install opens the same
+  // task-first experience as an existing session (including recommended
+  // agents and quick-start actions).
+  const [currentView, setCurrentView] = useState<AppView>("main");
   const [agentTeamSelectedRole, setAgentTeamSelectedRole] =
     useState<AgentRole | null>(null);
   const navigationHistoryRef = useRef<AppNavigationEntry[]>([
-    { view: "home", taskId: null },
+    { view: "main", taskId: null },
   ]);
   const navigationIndexRef = useRef(0);
   const navigationApplyTargetRef = useRef<AppNavigationEntry | null>(null);
@@ -2875,7 +2879,7 @@ export function App() {
   const sideChatRequestSeqRef = useRef(0);
   const selectedTaskIdRef = useRef<string | null>(null);
   const fetchedFullTaskForMentionMetadataRef = useRef<Set<string>>(new Set());
-  const currentViewRef = useRef<AppView>("home");
+  const currentViewRef = useRef<AppView>("main");
   const rightSidebarCollapsedRef = useRef(false);
   const currentWorkspaceRef = useRef<Workspace | null>(null);
   const noiseEventThrottleRef = useRef<Map<string, number>>(new Map());
@@ -8247,6 +8251,7 @@ export function App() {
                     );
                     setCurrentView("settings");
                   }}
+                  onOpenAgentManagement={() => setCurrentView("agentsManage")}
                   onStopTask={handleCancelTask}
                   onEnableShellForPausedTask={handleEnableShellForPausedTask}
                   onContinueWithoutShellForPausedTask={

--- a/src/renderer/__tests__/initial-view.test.ts
+++ b/src/renderer/__tests__/initial-view.test.ts
@@ -5,15 +5,15 @@ import { describe, expect, it } from "vitest";
 const appPath = fileURLToPath(new URL("../App.tsx", import.meta.url));
 
 describe("initial workspace view", () => {
-  it("opens the workspace dashboard on a fresh renderer session", () => {
+  it("opens the focused task-first welcome surface on a fresh renderer session", () => {
     const source = readFileSync(appPath, "utf8");
 
     expect(source).toContain(
-      'const [currentView, setCurrentView] = useState<AppView>("home")',
+      'const [currentView, setCurrentView] = useState<AppView>("main")',
     );
     expect(source).toContain(
-      'const currentViewRef = useRef<AppView>("home")',
+      'const currentViewRef = useRef<AppView>("main")',
     );
-    expect(source).toContain('{ view: "home", taskId: null }');
+    expect(source).toContain('{ view: "main", taskId: null }');
   });
 });

--- a/src/renderer/components/MainContent/MainContent.tsx
+++ b/src/renderer/components/MainContent/MainContent.tsx
@@ -104,6 +104,7 @@ import { localizeProgressText } from "../../utils/localized-progress-text";
 import { isCapabilityCatalogPlan } from "../../../shared/plan-quality";
 import { shouldShowComposerProgress } from "../../utils/right-panel-progress";
 import { getLocalizedSkillText } from "../../utils/localized-skills";
+import { getAgentRolePortrait } from "../../utils/agent-role-portraits";
 import {
   hasTaskOutputs,
   resolveTaskOutputSummaryFromCompletionEvent,
@@ -751,6 +752,7 @@ interface MainContentProps {
   onChangeWorkspace?: () => void;
   onSelectWorkspace?: (workspace: Workspace) => void;
   onOpenSettings?: (tab?: SettingsTab) => void;
+  onOpenAgentManagement?: () => void;
   onStopTask?: () => void;
   onEnableShellForPausedTask?: () => void | Promise<void>;
   onContinueWithoutShellForPausedTask?: () => void | Promise<void>;
@@ -4745,6 +4747,134 @@ function InlineOnboardingCard({
   );
 }
 
+type HomeAgentRoleEntry = {
+  id: string;
+  roleName: string;
+  name: string;
+  description: string;
+  source?: AgentRoleData;
+};
+
+const HOME_AGENT_ROLE_FALLBACKS = [
+  {
+    id: "researcher",
+    name: "研究员",
+    description: "调研方案并收集信息",
+    englishName: "Researcher",
+    englishDescription: "Research topics and collect evidence",
+  },
+  {
+    id: "coder",
+    name: "编码工程师",
+    description: "编写代码并实现功能",
+    englishName: "Coding engineer",
+    englishDescription: "Write code and implement features",
+  },
+  {
+    id: "data_analyst",
+    name: "数据分析师",
+    description: "分析数据并发现趋势",
+    englishName: "Data analyst",
+    englishDescription: "Analyze data and uncover trends",
+  },
+  {
+    id: "writer",
+    name: "内容撰写员",
+    description: "撰写文档与内容",
+    englishName: "Content writer",
+    englishDescription: "Write documents and content",
+  },
+] as const;
+
+function HomeAgentHub({
+  roles,
+  onSelect,
+  onViewAll,
+}: {
+  roles: AgentRoleData[];
+  onSelect: (roleName: string) => void;
+  onViewAll?: () => void;
+}) {
+  const language = useLanguage();
+  const isChinese = language === "zh-CN";
+  const entries = useMemo<HomeAgentRoleEntry[]>(() => {
+    return HOME_AGENT_ROLE_FALLBACKS.map((fallback) => {
+      const source = roles.find(
+        (role) => role.id === fallback.id || role.name === fallback.id,
+      );
+      if (!source) {
+        return {
+          id: fallback.id,
+          roleName: fallback.id,
+          name: isChinese ? fallback.name : fallback.englishName,
+          description: isChinese ? fallback.description : fallback.englishDescription,
+        };
+      }
+      const localized = getLocalizedAgentRoleText(source, language);
+      return {
+        id: source.id,
+        roleName: source.name,
+        name: localized.name,
+        description: localized.description || (isChinese ? fallback.description : fallback.englishDescription),
+        source,
+      };
+    });
+  }, [isChinese, language, roles]);
+
+  return (
+    <section className="nw-home-agent-hub" aria-labelledby="home-agent-hub-title">
+      <div className="focused-cards-section-header nw-home-agent-hub-header">
+        <div>
+          <h2 id="home-agent-hub-title">
+            {isChinese ? "推荐智能体" : "Recommended agents"}
+          </h2>
+          <p>
+            {isChinese
+              ? "选择合适的角色，直接开始一项工作"
+              : "Choose a role and start a task"}
+          </p>
+        </div>
+        {onViewAll && (
+          <button
+            type="button"
+            className="welcome-card-refresh"
+            onClick={onViewAll}
+            aria-label={isChinese ? "查看全部智能体" : "View all agents"}
+          >
+            <span>{isChinese ? "查看全部" : "View all"}</span>
+            <ChevronRight size={14} strokeWidth={1.8} aria-hidden="true" />
+          </button>
+        )}
+      </div>
+      <div className="nw-home-agent-grid" aria-live="polite">
+        {entries.map((entry) => (
+          <button
+            type="button"
+            className="nw-home-agent-card"
+            key={entry.id}
+            onClick={() => onSelect(entry.roleName)}
+            title={isChinese ? `由${entry.name}处理` : `Handled by ${entry.name}`}
+          >
+            <img
+              src={getAgentRolePortrait(entry.source || { name: entry.roleName })}
+              alt=""
+              aria-hidden="true"
+              className="nw-home-agent-portrait"
+            />
+            <span className="nw-home-agent-copy">
+              <span className="nw-home-agent-name">
+                <span className="nw-home-agent-status" aria-hidden="true" />
+                <span>{entry.name}</span>
+              </span>
+              <span className="nw-home-agent-description">{entry.description}</span>
+            </span>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 function MainContentComponent({
   task,
   selectedTaskId,
@@ -4769,6 +4899,7 @@ function MainContentComponent({
   onChangeWorkspace,
   onSelectWorkspace,
   onOpenSettings,
+  onOpenAgentManagement,
   onStopTask,
   onEnableShellForPausedTask,
   onContinueWithoutShellForPausedTask,
@@ -11326,6 +11457,14 @@ function MainContentComponent({
                 onOpenModelSettings={() => onOpenSettings?.("llm")}
                 onComplete={onCompleteInlineOnboarding}
                 onProfileSaved={agentContext.refresh}
+              />
+            )}
+
+            {uiDensity === "focused" && !outcomeTemplatesEnabled && (
+              <HomeAgentHub
+                roles={agentRoles}
+                onSelect={(roleName) => handleQuickAction(`@${roleName}`)}
+                onViewAll={onOpenAgentManagement}
               />
             )}
 

--- a/src/renderer/components/MainContent/__tests__/welcome-layout.test.ts
+++ b/src/renderer/components/MainContent/__tests__/welcome-layout.test.ts
@@ -160,6 +160,19 @@ describe("Welcome layout", () => {
     expect(source).toContain(".quick-start-affordance");
   });
 
+  it("keeps the latest focused homepage agent hub in the shipped source", () => {
+    const source = readFileSync(componentPath, "utf8");
+    const styles = readFileSync(stylesPath, "utf8");
+
+    expect(source).toMatch(/function\s+HomeAgentHub/);
+    expect(source).toContain('"推荐智能体"');
+    expect(source).toContain("getAgentRolePortrait");
+    expect(source).toMatch(/researcher[\s\S]*coder[\s\S]*data_analyst[\s\S]*writer/);
+    expect(source).toContain('onViewAll={onOpenAgentManagement}');
+    expect(styles).toMatch(/\.nw-home-agent-grid\s*\{[\s\S]*grid-template-columns:\s*repeat\(4/);
+    expect(styles).toContain(".nw-home-agent-card");
+  });
+
   it("fills recommendation prompts into the composer without executing them", () => {
     const component = readFileSync(componentPath, "utf8");
     const quickAction =

--- a/src/renderer/components/MainContent/main-content.css
+++ b/src/renderer/components/MainContent/main-content.css
@@ -18735,6 +18735,144 @@
   box-shadow: none;
 }
 
+/* Focused homepage recommended agents. Keep this row compact so the composer
+   and quick-start actions remain visible on laptop-sized windows. */
+.welcome-content.welcome-content-focused > .nw-home-agent-hub {
+  box-sizing: border-box;
+  width: 100%;
+  margin-top: 4px;
+}
+
+.nw-home-agent-hub-header {
+  margin-bottom: 8px;
+}
+
+.nw-home-agent-hub-header h2 {
+  margin: 0;
+  color: var(--color-text-primary, var(--color-text));
+  font-size: 12.5px;
+  font-weight: 650;
+  line-height: 1.4;
+}
+
+.nw-home-agent-hub-header p {
+  margin: 3px 0 0;
+  color: var(--color-text-muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.nw-home-agent-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.nw-home-agent-card {
+  display: grid;
+  min-width: 0;
+  min-height: 72px;
+  box-sizing: border-box;
+  grid-template-columns: 44px minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  overflow: hidden;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 12px;
+  color: var(--color-text);
+  background: var(--color-bg-elevated);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-text) 4%, transparent);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease,
+    transform 150ms ease;
+}
+
+.nw-home-agent-card:hover {
+  border-color: color-mix(in srgb, var(--color-accent) 30%, var(--color-border-subtle));
+  box-shadow: 0 9px 22px -16px color-mix(in srgb, var(--color-accent) 46%, var(--color-text));
+  transform: translateY(-2px);
+}
+
+.nw-home-agent-card:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--color-accent) 48%, transparent);
+  outline-offset: 2px;
+}
+
+.nw-home-agent-portrait {
+  display: block;
+  width: 44px;
+  height: 54px;
+  object-fit: cover;
+  object-position: top;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--color-accent) 7%, var(--color-bg-hover));
+}
+
+.nw-home-agent-copy {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+}
+
+.nw-home-agent-name {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+  color: var(--color-text-primary, var(--color-text));
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
+.nw-home-agent-name > span:last-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.nw-home-agent-status {
+  flex: 0 0 auto;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #19a974;
+  box-shadow: 0 0 0 2px #e8f8f1;
+}
+
+.nw-home-agent-description {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--color-text-muted);
+  font-size: 10.5px;
+  line-height: 1.35;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+@media (max-width: 760px) {
+  .nw-home-agent-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 520px) {
+  .nw-home-agent-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nw-home-agent-card {
+    transition: none;
+  }
+}
+
 .welcome-content.welcome-content-focused .quick-start-section .focused-cards-section-header {
   display: flex;
   min-height: 28px;

--- a/src/shared/product-brand.ts
+++ b/src/shared/product-brand.ts
@@ -1,3 +1,3 @@
 export const PRODUCT_NAME = "NeoWorker";
-export const PRODUCT_SEMVER = "0.1.5";
+export const PRODUCT_SEMVER = "0.1.6";
 export const PRODUCT_DISPLAY_VERSION = `V${PRODUCT_SEMVER}`;


### PR DESCRIPTION
## Summary
- restore the focused task-first welcome surface as the fresh-install default
- add the localized recommended-agent hub with portraits, role shortcuts, and management entry point
- add responsive layout and regression coverage; bump the shipped version to 0.1.6

## Validation
- `npm run build:react`
- focused Vitest regression suite (22 tests)
- `git diff --check`
